### PR TITLE
improve performance of `get_many`

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -993,10 +993,8 @@ class Collection(ApiGroup):
         :raise arango.exceptions.DocumentGetError: If retrieval fails.
         """
         handles = [self._extract_id(d) if isinstance(d, dict) else d for d in documents]
-        
-        params: Params = {
-            "onlyget": True
-        }
+
+        params: Params = {"onlyget": True}
 
         request = Request(
             method="put",


### PR DESCRIPTION
by making it use a different server REST API. It now uses the low-level
document API instead of the `/_api/simple/lookup-by-keys` API. The
former can be used as a drop-in replacement for the latter.