### PR TITLE
feat: Use HEAD HTTP method to check if a document exists

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -637,8 +637,6 @@ class Collection(ApiGroup):
         )
 
         def response_handler(resp: Response) -> bool:
-            if resp.error_code == 1202:
-                return False
             if resp.status_code == 412:
                 raise DocumentRevisionError(resp, request)
             if resp.status_code == 404:

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -630,7 +630,7 @@ class Collection(ApiGroup):
             headers["x-arango-allow-dirty-read"] = "true"
 
         request = Request(
-            method="get",
+            method="head",
             endpoint=f"/_api/document/{handle}",
             headers=headers,
             read=self.name,
@@ -641,9 +641,11 @@ class Collection(ApiGroup):
                 return False
             if resp.status_code == 412:
                 raise DocumentRevisionError(resp, request)
+            if resp.status_code == 404:
+                return False
             if not resp.is_success:
                 raise DocumentInError(resp, request)
-            return bool(resp.body)
+            return True
 
         return self._execute(request, response_handler)
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1554,7 +1554,7 @@ def test_document_has(col, bad_col, docs):
 
         with assert_raises(DocumentRevisionError) as err:
             col.has(doc_input, rev=bad_rev, check_rev=True)
-        assert err.value.error_code in {412, 1200}
+        assert err.value.error_code == 412
 
     # Test existing documents with bad revision
     for doc_input in [
@@ -1564,15 +1564,15 @@ def test_document_has(col, bad_col, docs):
     ]:
         with assert_raises(DocumentRevisionError) as err:
             col.has(doc_input)
-        assert err.value.error_code in {412, 1200}
+        assert err.value.error_code == 412
 
         with assert_raises(DocumentRevisionError) as err:
             col.has(doc_input, rev=bad_rev)
-        assert err.value.error_code in {412, 1200}
+        assert err.value.error_code == 412
 
         with assert_raises(DocumentRevisionError) as err:
             col.has(doc_input, rev=bad_rev, check_rev=True)
-        assert err.value.error_code in {412, 1200}
+        assert err.value.error_code == 412
 
         assert doc_input in col
         assert col.has(doc_input, rev=rev, check_rev=True) is True
@@ -1651,12 +1651,12 @@ def test_document_has(col, bad_col, docs):
     # Test get with bad database
     with assert_raises(DocumentInError) as err:
         bad_col.has(doc_key)
-    assert err.value.error_code in {11, 401}
+    assert err.value.error_code == 401
 
     # Test contains with bad database
     with assert_raises(DocumentInError) as err:
         assert doc_key in bad_col
-    assert err.value.error_code in {11, 401}
+    assert err.value.error_code == 401
 
 
 def test_document_get(col, bad_col, docs):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1554,7 +1554,7 @@ def test_document_has(col, bad_col, docs):
 
         with assert_raises(DocumentRevisionError) as err:
             col.has(doc_input, rev=bad_rev, check_rev=True)
-        assert err.value.error_code == 1200
+        assert err.value.error_code in {412, 1200}
 
     # Test existing documents with bad revision
     for doc_input in [
@@ -1564,15 +1564,15 @@ def test_document_has(col, bad_col, docs):
     ]:
         with assert_raises(DocumentRevisionError) as err:
             col.has(doc_input)
-        assert err.value.error_code == 1200
+        assert err.value.error_code in {412, 1200}
 
         with assert_raises(DocumentRevisionError) as err:
             col.has(doc_input, rev=bad_rev)
-        assert err.value.error_code == 1200
+        assert err.value.error_code in {412, 1200}
 
         with assert_raises(DocumentRevisionError) as err:
             col.has(doc_input, rev=bad_rev, check_rev=True)
-        assert err.value.error_code == 1200
+        assert err.value.error_code in {412, 1200}
 
         assert doc_input in col
         assert col.has(doc_input, rev=rev, check_rev=True) is True
@@ -1651,12 +1651,12 @@ def test_document_has(col, bad_col, docs):
     # Test get with bad database
     with assert_raises(DocumentInError) as err:
         bad_col.has(doc_key)
-    assert err.value.error_code in {11, 1228}
+    assert err.value.error_code in {11, 401}
 
     # Test contains with bad database
     with assert_raises(DocumentInError) as err:
         assert doc_key in bad_col
-    assert err.value.error_code in {11, 1228}
+    assert err.value.error_code in {11, 401}
 
 
 def test_document_get(col, bad_col, docs):


### PR DESCRIPTION
The current `has` method requests the full document to only check if it exists or not. It may be overkill for big documents.

This PR replaces it with a simple `HEAD` call allowing to know if the document exists or not.

:warning:  This PR will change the `error_code` returned. Since we don't have a body in the response, the `error_code` value will default to `status_code`.
If the only codes we should handle are the ones in the test, I could update the response object to set the appropriate `error_code` based on the status code.