### PR TITLE
update organization to `arangodb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 ![Logo](https://user-images.githubusercontent.com/2701938/108583516-c3576680-72ee-11eb-883f-2d9b52e74e45.png)
 
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/ArangoDB-Community/python-arango/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/ArangoDB-Community/python-arango/tree/main)
-[![CodeQL](https://github.com/ArangoDB-Community/python-arango/actions/workflows/codeql.yaml/badge.svg)](https://github.com/ArangoDB-Community/python-arango/actions/workflows/codeql.yaml)
-[![Docs](https://github.com/ArangoDB-Community/python-arango/actions/workflows/docs.yaml/badge.svg)](https://github.com/ArangoDB-Community/python-arango/actions/workflows/docs.yaml)
-[![Coverage Status](https://codecov.io/gh/ArangoDB-Community/python-arango/branch/main/graph/badge.svg?token=M8zrjrzsUY)](https://codecov.io/gh/ArangoDB-Community/python-arango)
-[![Last commit](https://img.shields.io/github/last-commit/ArangoDB-Community/python-arango)](https://github.com/ArangoDB-Community/python-arango/commits/master)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/arangodb/python-arango/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/arangodb/python-arango/tree/main)
+[![CodeQL](https://github.com/arangodb/python-arango/actions/workflows/codeql.yaml/badge.svg)](https://github.com/arangodb/python-arango/actions/workflows/codeql.yaml)
+[![Docs](https://github.com/arangodb/python-arango/actions/workflows/docs.yaml/badge.svg)](https://github.com/arangodb/python-arango/actions/workflows/docs.yaml)
+[![Coverage Status](https://codecov.io/gh/arangodb/python-arango/branch/main/graph/badge.svg?token=M8zrjrzsUY)](https://codecov.io/gh/arangodb/python-arango)
+[![Last commit](https://img.shields.io/github/last-commit/arangodb/python-arango)](https://github.com/arangodb/python-arango/commits/master)
 
 [![PyPI version badge](https://img.shields.io/pypi/v/python-arango?color=3775A9&style=for-the-badge&logo=pypi&logoColor=FFD43B)](https://pypi.org/project/python-arango/)
 [![Python versions badge](https://img.shields.io/badge/3.8%2B-3776AB?style=for-the-badge&logo=python&logoColor=FFD43B&label=Python)](https://pypi.org/project/python-arango/)
 
-[![License](https://img.shields.io/github/license/ArangoDB-Community/python-arango?color=9E2165&style=for-the-badge)](https://github.com/ArangoDB-Community/python-arango/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/arangodb/python-arango?color=9E2165&style=for-the-badge)](https://github.com/arangodb/python-arango/blob/master/LICENSE)
 [![Code style: black](https://img.shields.io/static/v1?style=for-the-badge&label=code%20style&message=black&color=black)](https://github.com/psf/black)
 [![Downloads](https://img.shields.io/pepy/dt/python-arango?style=for-the-badge&color=282661
 )](https://pepy.tech/project/python-arango)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -40,7 +40,7 @@ To ensure PEP8_ compliance, run flake8_:
 .. code-block:: bash
 
     ~$ pip install flake8
-    ~$ git clone https://github.com/ArangoDB-Community/python-arango.git
+    ~$ git clone https://github.com/arangodb/python-arango.git
     ~$ cd python-arango
     ~$ flake8
 
@@ -57,7 +57,7 @@ To run the test suite (use your own host, port and root password):
 .. code-block:: bash
 
     ~$ pip install pytest
-    ~$ git clone https://github.com/ArangoDB-Community/python-arango.git
+    ~$ git clone https://github.com/arangodb/python-arango.git
     ~$ cd python-arango
     ~$ py.test --complete --host=127.0.0.1 --port=8529 --passwd=passwd
 
@@ -66,7 +66,7 @@ To run the test suite with coverage report:
 .. code-block:: bash
 
     ~$ pip install coverage pytest pytest-cov
-    ~$ git clone https://github.com/ArangoDB-Community/python-arango.git
+    ~$ git clone https://github.com/arangodb/python-arango.git
     ~$ cd python-arango
     ~$ py.test --complete --host=127.0.0.1 --port=8529 --passwd=passwd --cov=kq
 
@@ -82,7 +82,7 @@ Sphinx_. To build an HTML version on your local machine:
 .. code-block:: bash
 
     ~$ pip install sphinx sphinx_rtd_theme
-    ~$ git clone https://github.com/ArangoDB-Community/python-arango.git
+    ~$ git clone https://github.com/arangodb/python-arango.git
     ~$ cd python-arango
     ~$ python -m sphinx -b html -W docs docs/_build/  # Open build/index.html in a browser
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
 "arango" = ["py.typed"]
 
 [project.urls]
-homepage = "https://github.com/ArangoDB-Community/python-arango"
+homepage = "https://github.com/arangodb/python-arango"
 
 [tool.setuptools]
 packages = ["arango"]


### PR DESCRIPTION
Moving this repo from `github.com/ArangoDB-Community` to `github.com/arangodb`