### PR TITLE
[3.12]: External versioning support

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1816,8 +1816,6 @@ class Collection(ApiGroup):
         param version_attribute: support for simple external versioning to
             document operations.
         :type version_attribute: str
-        :return: Document metadata (e.g. document key, revision) or True if
-            parameter **silent** was set to True.
         :return: List of document metadata (e.g. document keys, revisions) and
             any exception, or True if parameter **silent** was set to True.
         :rtype: [dict | ArangoServerError] | bool

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1813,9 +1813,9 @@ class Collection(ApiGroup):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to 
+        param version_attribute: support for simple external versioning to
             document operations.
-        :type version_attribute: str    
+        :type version_attribute: str
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
         :return: List of document metadata (e.g. document keys, revisions) and
@@ -1888,7 +1888,7 @@ class Collection(ApiGroup):
         silent: bool = False,
         refill_index_caches: Optional[bool] = None,
         raise_on_document_error: bool = False,
-        version_attribute: Optional[str] = None
+        version_attribute: Optional[str] = None,
     ) -> Result[Union[bool, List[Union[Json, ArangoServerError]]]]:
         """Update multiple documents.
 
@@ -1941,9 +1941,9 @@ class Collection(ApiGroup):
             as opposed to returning the error as an object in the result list.
             Defaults to False.
         :type raise_on_document_error: bool
-        param version_attribute: support for simple external versioning to 
+        param version_attribute: support for simple external versioning to
             document operations.
-        :type version_attribute: str    
+        :type version_attribute: str
         :return: List of document metadata (e.g. document keys, revisions) and
             any exceptions, or True if parameter **silent** was set to True.
         :rtype: [dict | ArangoError] | bool
@@ -2098,7 +2098,7 @@ class Collection(ApiGroup):
         sync: Optional[bool] = None,
         silent: bool = False,
         refill_index_caches: Optional[bool] = None,
-        version_attribute: Optional[str] = None
+        version_attribute: Optional[str] = None,
     ) -> Result[Union[bool, List[Union[Json, ArangoServerError]]]]:
         """Replace multiple documents.
 
@@ -2140,9 +2140,9 @@ class Collection(ApiGroup):
             index caches if document operations affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to 
+        param version_attribute: support for simple external versioning to
             document operations.
-        :type version_attribute: str    
+        :type version_attribute: str
         :return: List of document metadata (e.g. document keys, revisions) and
             any exceptions, or True if parameter **silent** was set to True.
         :rtype: [dict | ArangoServerError] | bool
@@ -2153,7 +2153,7 @@ class Collection(ApiGroup):
             "returnOld": return_old,
             "ignoreRevs": not check_rev,
             "overwrite": not check_rev,
-            "silent": silent
+            "silent": silent,
         }
         if sync is not None:
             params["waitForSync"] = sync
@@ -2633,7 +2633,7 @@ class StandardCollection(Collection):
         keep_none: Optional[bool] = None,
         merge: Optional[bool] = None,
         refill_index_caches: Optional[bool] = None,
-        version_attribute: Optional[str] = None
+        version_attribute: Optional[str] = None,
     ) -> Result[Union[bool, Json]]:
         """Insert a new document.
 
@@ -2672,9 +2672,9 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to 
+        param version_attribute: support for simple external versioning to
             document operations.
-        :type version_attribute: str   
+        :type version_attribute: str
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
         :rtype: bool | dict
@@ -2736,7 +2736,7 @@ class StandardCollection(Collection):
         sync: Optional[bool] = None,
         silent: bool = False,
         refill_index_caches: Optional[bool] = None,
-        version_attribute: Optional[str] = None
+        version_attribute: Optional[str] = None,
     ) -> Result[Union[bool, Json]]:
         """Update a document.
 
@@ -2767,9 +2767,9 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning 
+        param version_attribute: support for simple external versioning
             to document operations.
-        :type version_attribute: str    
+        :type version_attribute: str
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
         :rtype: bool | dict
@@ -2783,7 +2783,7 @@ class StandardCollection(Collection):
             "returnOld": return_old,
             "ignoreRevs": not check_rev,
             "overwrite": not check_rev,
-            "silent": silent
+            "silent": silent,
         }
         if sync is not None:
             params["waitForSync"] = sync
@@ -2826,7 +2826,7 @@ class StandardCollection(Collection):
         sync: Optional[bool] = None,
         silent: bool = False,
         refill_index_caches: Optional[bool] = None,
-        version_attribute: Optional[str] = None
+        version_attribute: Optional[str] = None,
     ) -> Result[Union[bool, Json]]:
         """Replace a document.
 
@@ -2852,9 +2852,9 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to 
+        param version_attribute: support for simple external versioning to
             document operations.
-        :type version_attribute: str    
+        :type version_attribute: str
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
         :rtype: bool | dict
@@ -2866,7 +2866,7 @@ class StandardCollection(Collection):
             "returnOld": return_old,
             "ignoreRevs": not check_rev,
             "overwrite": not check_rev,
-            "silent": silent
+            "silent": silent,
         }
         if sync is not None:
             params["waitForSync"] = sync

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1758,6 +1758,7 @@ class Collection(ApiGroup):
         keep_none: Optional[bool] = None,
         merge: Optional[bool] = None,
         refill_index_caches: Optional[bool] = None,
+        version_attribute: Optional[str] = None,
     ) -> Result[Union[bool, List[Union[Json, ArangoServerError]]]]:
         """Insert multiple documents.
 
@@ -1812,6 +1813,10 @@ class Collection(ApiGroup):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
+        param version_attribute: support for simple external versioning to document operations.
+        :type version_attribute: str    
+        :return: Document metadata (e.g. document key, revision) or True if
+            parameter **silent** was set to True.
         :return: List of document metadata (e.g. document keys, revisions) and
             any exception, or True if parameter **silent** was set to True.
         :rtype: [dict | ArangoServerError] | bool
@@ -1834,6 +1839,8 @@ class Collection(ApiGroup):
             params["keepNull"] = keep_none
         if merge is not None:
             params["mergeObjects"] = merge
+        if version_attribute is not None:
+            params["versionAttribute"] = version_attribute
 
         # New in ArangoDB 3.9.6 and 3.10.2
         if refill_index_caches is not None:
@@ -1880,6 +1887,7 @@ class Collection(ApiGroup):
         silent: bool = False,
         refill_index_caches: Optional[bool] = None,
         raise_on_document_error: bool = False,
+        version_attribute: Optional[str] = None
     ) -> Result[Union[bool, List[Union[Json, ArangoServerError]]]]:
         """Update multiple documents.
 
@@ -1932,6 +1940,8 @@ class Collection(ApiGroup):
             as opposed to returning the error as an object in the result list.
             Defaults to False.
         :type raise_on_document_error: bool
+        param version_attribute: support for simple external versioning to document operations.
+        :type version_attribute: str    
         :return: List of document metadata (e.g. document keys, revisions) and
             any exceptions, or True if parameter **silent** was set to True.
         :rtype: [dict | ArangoError] | bool
@@ -1948,6 +1958,8 @@ class Collection(ApiGroup):
         }
         if sync is not None:
             params["waitForSync"] = sync
+        if version_attribute is not None:
+            params["versionAttribute"] = version_attribute
 
         # New in ArangoDB 3.9.6 and 3.10.2
         if refill_index_caches is not None:
@@ -2084,6 +2096,7 @@ class Collection(ApiGroup):
         sync: Optional[bool] = None,
         silent: bool = False,
         refill_index_caches: Optional[bool] = None,
+        version_attribute: Optional[str] = None
     ) -> Result[Union[bool, List[Union[Json, ArangoServerError]]]]:
         """Replace multiple documents.
 
@@ -2125,6 +2138,8 @@ class Collection(ApiGroup):
             index caches if document operations affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
+        param version_attribute: support for simple external versioning to document operations.
+        :type version_attribute: str    
         :return: List of document metadata (e.g. document keys, revisions) and
             any exceptions, or True if parameter **silent** was set to True.
         :rtype: [dict | ArangoServerError] | bool
@@ -2135,10 +2150,12 @@ class Collection(ApiGroup):
             "returnOld": return_old,
             "ignoreRevs": not check_rev,
             "overwrite": not check_rev,
-            "silent": silent,
+            "silent": silent
         }
         if sync is not None:
             params["waitForSync"] = sync
+        if version_attribute is not None:
+            params["versionAttribute"] = version_attribute
 
         # New in ArangoDB 3.9.6 and 3.10.2
         if refill_index_caches is not None:
@@ -2613,6 +2630,7 @@ class StandardCollection(Collection):
         keep_none: Optional[bool] = None,
         merge: Optional[bool] = None,
         refill_index_caches: Optional[bool] = None,
+        version_attribute: Optional[str] = None
     ) -> Result[Union[bool, Json]]:
         """Insert a new document.
 
@@ -2651,6 +2669,8 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
+        param version_attribute: support for simple external versioning to document operations.
+        :type version_attribute: str   
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
         :rtype: bool | dict
@@ -2672,6 +2692,8 @@ class StandardCollection(Collection):
             params["keepNull"] = keep_none
         if merge is not None:
             params["mergeObjects"] = merge
+        if version_attribute is not None:
+            params["versionAttribute"] = version_attribute
 
         # New in ArangoDB 3.9.6 and 3.10.2
         if refill_index_caches is not None:
@@ -2710,6 +2732,7 @@ class StandardCollection(Collection):
         sync: Optional[bool] = None,
         silent: bool = False,
         refill_index_caches: Optional[bool] = None,
+        version_attribute: Optional[str] = None
     ) -> Result[Union[bool, Json]]:
         """Update a document.
 
@@ -2740,6 +2763,8 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
+        param version_attribute: support for simple external versioning to document operations.
+        :type version_attribute: str    
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
         :rtype: bool | dict
@@ -2754,6 +2779,7 @@ class StandardCollection(Collection):
             "ignoreRevs": not check_rev,
             "overwrite": not check_rev,
             "silent": silent,
+            "versionAttribute": version_attribute
         }
         if sync is not None:
             params["waitForSync"] = sync
@@ -2793,6 +2819,7 @@ class StandardCollection(Collection):
         sync: Optional[bool] = None,
         silent: bool = False,
         refill_index_caches: Optional[bool] = None,
+        version_attribute: Optional[str] = None
     ) -> Result[Union[bool, Json]]:
         """Replace a document.
 
@@ -2818,6 +2845,8 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
+        param version_attribute: support for simple external versioning to document operations.
+        :type version_attribute: str    
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
         :rtype: bool | dict
@@ -2830,6 +2859,7 @@ class StandardCollection(Collection):
             "ignoreRevs": not check_rev,
             "overwrite": not check_rev,
             "silent": silent,
+            "versionAttribute": version_attribute
         }
         if sync is not None:
             params["waitForSync"] = sync

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1813,7 +1813,8 @@ class Collection(ApiGroup):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to document operations.
+        param version_attribute: support for simple external versioning to 
+            document operations.
         :type version_attribute: str    
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
@@ -1940,7 +1941,8 @@ class Collection(ApiGroup):
             as opposed to returning the error as an object in the result list.
             Defaults to False.
         :type raise_on_document_error: bool
-        param version_attribute: support for simple external versioning to document operations.
+        param version_attribute: support for simple external versioning to 
+            document operations.
         :type version_attribute: str    
         :return: List of document metadata (e.g. document keys, revisions) and
             any exceptions, or True if parameter **silent** was set to True.
@@ -2138,7 +2140,8 @@ class Collection(ApiGroup):
             index caches if document operations affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to document operations.
+        param version_attribute: support for simple external versioning to 
+            document operations.
         :type version_attribute: str    
         :return: List of document metadata (e.g. document keys, revisions) and
             any exceptions, or True if parameter **silent** was set to True.
@@ -2669,7 +2672,8 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to document operations.
+        param version_attribute: support for simple external versioning to 
+            document operations.
         :type version_attribute: str   
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
@@ -2763,7 +2767,8 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to document operations.
+        param version_attribute: support for simple external versioning 
+            to document operations.
         :type version_attribute: str    
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.
@@ -2845,7 +2850,8 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to document operations.
+        param version_attribute: support for simple external versioning to 
+            document operations.
         :type version_attribute: str    
         :return: Document metadata (e.g. document key, revision) or True if
             parameter **silent** was set to True.

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -2783,11 +2783,13 @@ class StandardCollection(Collection):
             "returnOld": return_old,
             "ignoreRevs": not check_rev,
             "overwrite": not check_rev,
-            "silent": silent,
-            "versionAttribute": version_attribute
+            "silent": silent
         }
         if sync is not None:
             params["waitForSync"] = sync
+
+        if version_attribute is not None:
+            params["versionAttribute"] = version_attribute
 
         # New in ArangoDB 3.9.6 and 3.10.2
         if refill_index_caches is not None:
@@ -2864,11 +2866,13 @@ class StandardCollection(Collection):
             "returnOld": return_old,
             "ignoreRevs": not check_rev,
             "overwrite": not check_rev,
-            "silent": silent,
-            "versionAttribute": version_attribute
+            "silent": silent
         }
         if sync is not None:
             params["waitForSync"] = sync
+
+        if version_attribute is not None:
+            params["versionAttribute"] = version_attribute
 
         # New in ArangoDB 3.9.6 and 3.10.2
         if refill_index_caches is not None:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,4 +1,5 @@
 import pytest
+from packaging import version
 
 from arango.exceptions import (
     DocumentCountError,
@@ -24,7 +25,6 @@ from tests.helpers import (
     generate_doc_key,
 )
 
-from packaging import version
 
 def test_document_insert(col, docs):
     # Test insert document with no key
@@ -2069,31 +2069,27 @@ def test_document_management_via_db(db, col):
     assert doc1_id not in col
     assert len(col) == 2
 
+
 def test_version_attributes(db, coll, db_version):
     if db_version < version.parse("3.12.0"):
         pytest.skip("Version attributes is tested in 3.12.0+")
 
     docs = [
-        { "_key": "test1", "version": 2 },
-        { "_key": "test1", "version": 3 },
-        { "_key": "test1", "version": 1 },
-        { "_key": "test2", "version": 1 },
-        { "_key": "test2", "version": 9 },
-        { "_key": "test2", "version": 42 },
-        { "_key": "test2", "version": 0 },
-        { "_key": "test3" },
-        { "_key": "test3", "version": 5 },
-        { "_key": "test3", "version": 4 },
-        { "_key": "test3", "value": 2 },
+        {"_key": "test1", "version": 2},
+        {"_key": "test1", "version": 3},
+        {"_key": "test1", "version": 1},
+        {"_key": "test2", "version": 1},
+        {"_key": "test2", "version": 9},
+        {"_key": "test2", "version": 42},
+        {"_key": "test2", "version": 0},
+        {"_key": "test3"},
+        {"_key": "test3", "version": 5},
+        {"_key": "test3", "version": 4},
+        {"_key": "test3", "value": 2},
     ]
 
-    coll.insert_many(docs, version_attribute='version')
-    
+    coll.insert_many(docs, version_attribute="version")
+
     assert coll["test1"]["version"] == 3
     assert coll["test2"]["version"] == 42
     assert coll["test3"]["version"] == 5
-
-
-
-
-    

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -24,6 +24,7 @@ from tests.helpers import (
     generate_doc_key,
 )
 
+from packaging import version
 
 def test_document_insert(col, docs):
     # Test insert document with no key
@@ -2067,3 +2068,32 @@ def test_document_management_via_db(db, col):
     assert result["_id"] == doc1_id
     assert doc1_id not in col
     assert len(col) == 2
+
+def test_version_attributes(db, coll, db_version):
+    if db_version < version.parse("3.12.0"):
+        pytest.skip("Version attributes is tested in 3.12.0+")
+
+    docs = [
+        { "_key": "test1", "version": 2 },
+        { "_key": "test1", "version": 3 },
+        { "_key": "test1", "version": 1 },
+        { "_key": "test2", "version": 1 },
+        { "_key": "test2", "version": 9 },
+        { "_key": "test2", "version": 42 },
+        { "_key": "test2", "version": 0 },
+        { "_key": "test3" },
+        { "_key": "test3", "version": 5 },
+        { "_key": "test3", "version": 4 },
+        { "_key": "test3", "value": 2 },
+    ]
+
+    coll.insert_many(docs, version_attribute='version')
+    
+    assert coll["test1"]["version"] == 3
+    assert coll["test2"]["version"] == 42
+    assert coll["test3"]["version"] == 5
+
+
+
+
+    

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 from packaging import version
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -2070,7 +2070,7 @@ def test_document_management_via_db(db, col):
     assert len(col) == 2
 
 
-def test_version_attributes(db, coll, db_version):
+def test_version_attributes(col, db_version):
     if db_version < version.parse("3.12.0"):
         pytest.skip("Version attributes is tested in 3.12.0+")
 
@@ -2088,8 +2088,8 @@ def test_version_attributes(db, coll, db_version):
         {"_key": "test3", "value": 2},
     ]
 
-    coll.insert_many(docs, version_attribute="version")
+    col.insert_many(docs, version_attribute="version")
 
-    assert coll["test1"]["version"] == 3
-    assert coll["test2"]["version"] == 42
-    assert coll["test3"]["version"] == 5
+    assert col["test1"]["version"] == 3
+    assert col["test2"]["version"] == 42
+    assert col["test3"]["version"] == 5


### PR DESCRIPTION
This PR adds support for External versioning which is introduced in 3.12: https://github.com/arangodb/arangodb/pull/20382

https://arangodb.atlassian.net/browse/ES-1771?atlOrigin=eyJpIjoiMzM4NDI1MDkxMzBlNDA2MjhkZjUyOGI2NDc3NmJlNzIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

https://arangodb.atlassian.net/browse/ES-1771