### PR TITLE
[DE-716] Compression of requests and responses

### DIFF
--- a/arango/client.py
+++ b/arango/client.py
@@ -91,10 +91,10 @@ class ArangoClient:
        int: Timeout value in seconds.
     :type request_timeout: int | float
     :param request_compression: Will compress requests to the server according to
-        the given algorithm. Currently only `deflate` is supported.
+        the given algorithm. No compression happens by default.
     :type request_compression: arango.http.RequestCompression | None
     :param response_compression: Tells the server what compression algorithm is
-        acceptable for the response
+        acceptable for the response. No compression happens by default.
     :type response_compression: str | None
     """
 

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1813,7 +1813,7 @@ class Collection(ApiGroup):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to
+        :param version_attribute: support for simple external versioning to
             document operations.
         :type version_attribute: str
         :return: List of document metadata (e.g. document keys, revisions) and
@@ -1939,7 +1939,7 @@ class Collection(ApiGroup):
             as opposed to returning the error as an object in the result list.
             Defaults to False.
         :type raise_on_document_error: bool
-        param version_attribute: support for simple external versioning to
+        :param version_attribute: support for simple external versioning to
             document operations.
         :type version_attribute: str
         :return: List of document metadata (e.g. document keys, revisions) and
@@ -2138,7 +2138,7 @@ class Collection(ApiGroup):
             index caches if document operations affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to
+        :param version_attribute: support for simple external versioning to
             document operations.
         :type version_attribute: str
         :return: List of document metadata (e.g. document keys, revisions) and
@@ -2670,7 +2670,7 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to
+        :param version_attribute: support for simple external versioning to
             document operations.
         :type version_attribute: str
         :return: Document metadata (e.g. document key, revision) or True if
@@ -2765,7 +2765,7 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning
+        :param version_attribute: support for simple external versioning
             to document operations.
         :type version_attribute: str
         :return: Document metadata (e.g. document key, revision) or True if
@@ -2850,7 +2850,7 @@ class StandardCollection(Collection):
             index caches if document insertions affect the edge index or
             cache-enabled persistent indexes.
         :type refill_index_caches: bool | None
-        param version_attribute: support for simple external versioning to
+        :param version_attribute: support for simple external versioning to
             document operations.
         :type version_attribute: str
         :return: Document metadata (e.g. document key, revision) or True if

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -144,7 +144,9 @@ class BaseConnection:
             and isinstance(data, str)
             and self._request_compression.needs_compression(data)
         ):
-            request.headers["content-encoding"] = "deflate"
+            request.headers[
+                "content-encoding"
+            ] = self._request_compression.content_encoding()
             data = self._request_compression.compress(data)
 
         if self._response_compression is not None:

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -144,9 +144,7 @@ class BaseConnection:
             and isinstance(data, str)
             and self._request_compression.needs_compression(data)
         ):
-            request.headers[
-                "content-encoding"
-            ] = self._request_compression.content_encoding()
+            request.headers["content-encoding"] = self._request_compression.encoding()
             data = self._request_compression.compress(data)
 
         if self._response_compression is not None:

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -146,6 +146,8 @@ class BaseConnection:
             request.headers["content-encoding"] = "deflate"
             data = zlib.compress(data.encode("utf-8"))
 
+        request.headers["accept-encoding"] = "deflate, gzip"
+
         while tries < self._host_resolver.max_tries:
             try:
                 resp = self._http.send_request(

--- a/arango/http.py
+++ b/arango/http.py
@@ -40,7 +40,7 @@ class HTTPClient(ABC):  # pragma: no cover
         url: str,
         headers: Optional[Headers] = None,
         params: Optional[MutableMapping[str, str]] = None,
-        data: Union[str, MultipartEncoder, None] = None,
+        data: Union[str, bytes, MultipartEncoder, None] = None,
         auth: Optional[Tuple[str, str]] = None,
     ) -> Response:
         """Send an HTTP request.
@@ -58,7 +58,7 @@ class HTTPClient(ABC):  # pragma: no cover
         :param params: URL (query) parameters.
         :type params: dict
         :param data: Request payload.
-        :type data: str | MultipartEncoder | None
+        :type data: str | bytes | MultipartEncoder | None
         :param auth: Username and password.
         :type auth: tuple
         :returns: HTTP response.
@@ -198,7 +198,7 @@ class DefaultHTTPClient(HTTPClient):
         url: str,
         headers: Optional[Headers] = None,
         params: Optional[MutableMapping[str, str]] = None,
-        data: Union[str, MultipartEncoder, None] = None,
+        data: Union[str, bytes, MultipartEncoder, None] = None,
         auth: Optional[Tuple[str, str]] = None,
     ) -> Response:
         """Send an HTTP request.
@@ -214,7 +214,7 @@ class DefaultHTTPClient(HTTPClient):
         :param params: URL (query) parameters.
         :type params: dict
         :param data: Request payload.
-        :type data: str | MultipartEncoder | None
+        :type data: str | bytes | MultipartEncoder | None
         :param auth: Username and password.
         :type auth: tuple
         :returns: HTTP response.

--- a/arango/http.py
+++ b/arango/http.py
@@ -271,7 +271,7 @@ class RequestCompression(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def content_encoding(self) -> str:
+    def encoding(self) -> str:
         """Return the content encoding exactly as it should
             appear in the headers.
 
@@ -314,5 +314,5 @@ class DeflateRequestCompression(RequestCompression):
         """
         return zlib.compress(data.encode("utf-8"), level=self._level)
 
-    def content_encoding(self) -> str:
+    def encoding(self) -> str:
         return "deflate"

--- a/arango/http.py
+++ b/arango/http.py
@@ -251,8 +251,7 @@ class RequestCompression(ABC):
 
     @abstractmethod
     def needs_compression(self, data: str) -> bool:
-        """Return True if the data needs to be compressed.
-
+        """
         :param data: Data to be compressed.
         :type data: str
         :returns: True if the data needs to be compressed.
@@ -275,7 +274,7 @@ class RequestCompression(ABC):
 class DeflateRequestCompression(RequestCompression):
     """Compress requests using the 'deflate' algorithm."""
 
-    def __init__(self, threshold: int, level: int = -1):
+    def __init__(self, threshold: int = 1024, level: int = 6):
         """
         :param threshold: Will compress requests to the server if
         the size of the request body (in bytes) is at least the value of this

--- a/arango/http.py
+++ b/arango/http.py
@@ -270,6 +270,16 @@ class RequestCompression(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def content_encoding(self) -> str:
+        """Return the content encoding exactly as it should
+            appear in the headers.
+
+        :returns: Content encoding.
+        :rtype: str
+        """
+        raise NotImplementedError
+
 
 class DeflateRequestCompression(RequestCompression):
     """Compress requests using the 'deflate' algorithm."""
@@ -287,8 +297,7 @@ class DeflateRequestCompression(RequestCompression):
         self._level = level
 
     def needs_compression(self, data: str) -> bool:
-        """Return True if the data needs to be compressed.
-
+        """
         :param data: Data to be compressed.
         :type data: str
         :returns: True if the data needs to be compressed.
@@ -297,11 +306,13 @@ class DeflateRequestCompression(RequestCompression):
         return len(data) >= self._threshold
 
     def compress(self, data: str) -> bytes:
-        """Compress the data.
-
+        """
         :param data: Data to be compressed.
         :type data: str
         :returns: Compressed data.
         :rtype: bytes
         """
         return zlib.compress(data.encode("utf-8"), level=self._level)
+
+    def content_encoding(self) -> str:
+        return "deflate"

--- a/arango/http.py
+++ b/arango/http.py
@@ -246,7 +246,7 @@ class DefaultHTTPClient(HTTPClient):
         )
 
 
-class RequestCompression(ABC):
+class RequestCompression(ABC):  # pragma: no cover
     """Abstract base class for request compression."""
 
     @abstractmethod

--- a/docs/compression.rst
+++ b/docs/compression.rst
@@ -1,0 +1,40 @@
+Compression
+------------
+
+The :ref:`ArangoClient` lets you define the preferred compression policy for request and responses. By default
+compression is disabled. You can change this by setting the `request_compression` and `response_compression` parameters
+when creating the client. Currently, only the "deflate" compression algorithm is supported.
+
+.. testcode::
+
+    from arango import ArangoClient
+
+    from http import DeflateRequestCompression
+
+    client = ArangoClient(
+        hosts='http://localhost:8529',
+        request_compression=DeflateRequestCompression(),
+        response_compression="deflate"
+    )
+
+Furthermore, you can customize the request compression policy by defining the minimum size of the request body that
+should be compressed and the desired compression level. For example, the following code sets the minimum size to 2 KB
+and the compression level to 8:
+
+.. code-block:: python
+
+    client = ArangoClient(
+        hosts='http://localhost:8529',
+        request_compression=DeflateRequestCompression(
+            threshold=2048,
+            level=8),
+    )
+
+If you want to implement your own compression policy, you can do so by implementing the
+:class:`arango.http.RequestCompression` interface.
+
+.. note::
+    The `response_compression` parameter is only used to inform the server that the client prefers compressed responses
+    (in the form of an *Accept-Encoding* header). Note that the server may or may not honor this preference, depending
+    on how it is configured. This can be controlled by setting the `--http.compress-response-threshold` option to
+    a value greater than 0 when starting the ArangoDB server.

--- a/docs/compression.rst
+++ b/docs/compression.rst
@@ -9,7 +9,7 @@ when creating the client. Currently, only the "deflate" compression algorithm is
 
     from arango import ArangoClient
 
-    from http import DeflateRequestCompression
+    from arango.http import DeflateRequestCompression
 
     client = ArangoClient(
         hosts='http://localhost:8529',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,6 +80,7 @@ Miscellaneous
     logging
     auth
     http
+    compression
     serializer
     schema
     cursor

--- a/docs/specs.rst
+++ b/docs/specs.rst
@@ -103,6 +103,12 @@ DefaultHTTPClient
 .. autoclass:: arango.http.DefaultHTTPClient
     :members:
 
+DeflateRequestCompression
+=========================
+
+.. autoclass:: arango.http.DeflateRequestCompression
+    :members:
+
 .. _EdgeCollection:
 
 EdgeCollection


### PR DESCRIPTION
Adding compression of requests and responses, as implemented in https://github.com/arangodb/arangodb/pull/20128

By default compression is turned off, so this change has no effect unless the user specifies one of the newly introduced parameters.

The `ArangoClient` gets two optional parameters:
- `request_compression` - Represents the compression strategy, `None` by default. The reason for passing in an object instead of a string (such as *deflate*) is to allow the client to fine tune the compression algorithm.
- `response_compression` - The equivalent of an `Accept-Encoding` string. This has no effect unless the server is configured to use encoding.

```python
client = ArangoClient(
    hosts="http://127.0.0.1:8529",
    request_compression=DeflateRequestCompression(),
    response_compression="deflate",
)
```

A new documentation page has been added specifically for guiding users on how to use compression.