### PR TITLE
Failing Pregel Doctest

### DIFF
--- a/docs/pregel.rst
+++ b/docs/pregel.rst
@@ -12,7 +12,7 @@ iterative graph processing. For more information, refer to `ArangoDB manual`_.
 
 **Example:**
 
-.. testcode::
+.. code-block:: python
 
     from arango import ArangoClient
 


### PR DESCRIPTION
Because Pregel is deprecated since ArangoDB 3.12, its doctest has suddenly started failing as a new arangodb docker image got release (our doctest config always pulls `arangodb/arangodb:latest`).
I suggest we still keep the Pregel examples for now, as the API is still usable with supported versions (3.10 and 3.11), but deactive the testing. Example code was ok until now and is not going to change anymore. 