### PR TITLE
update arangodb matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
               python_version: ["3.8", "3.9", "3.10", "3.11"] # "3.12"
               arangodb_config: ["single", "cluster"]
               arangodb_license: ["community", "enterprise"]
-              arangodb_version: ["3.10.10", "3.11.4", "latest"]
+              arangodb_version: ["3.10", "3.11", "latest"]
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
               python_version: ["3.8", "3.9", "3.10", "3.11"] # "3.12"
               arangodb_config: ["single", "cluster"]
               arangodb_license: ["community", "enterprise"]
-              arangodb_version: ["3.10", "3.11", "latest"]
+              arangodb_version: ["3.11", "latest"]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ database natively supporting documents, graphs and search.
 
 ## Requirements
 
-- ArangoDB version 3.9+
+- ArangoDB version 3.11+
 - Python version 3.8+
 
 ## Installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Welcome to the documentation for **python-arango**, a Python driver for ArangoDB
 Requirements
 =============
 
-- ArangoDB version 3.9+
+- ArangoDB version 3.11+
 - Python version 3.8+
 
 Installation

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,5 +1,3 @@
-from packaging import version
-
 from arango.exceptions import (
     AnalyzerCreateError,
     AnalyzerDeleteError,
@@ -9,7 +7,7 @@ from arango.exceptions import (
 from tests.helpers import assert_raises, generate_analyzer_name
 
 
-def test_analyzer_management(db, bad_db, cluster, enterprise, db_version):
+def test_analyzer_management(db, bad_db, cluster, enterprise):
     analyzer_name = generate_analyzer_name()
     full_analyzer_name = db.name + "::" + analyzer_name
     bad_analyzer_name = generate_analyzer_name()
@@ -60,7 +58,7 @@ def test_analyzer_management(db, bad_db, cluster, enterprise, db_version):
     assert db.delete_analyzer(analyzer_name, ignore_missing=True) is False
 
     # Test create geo_s2 analyzer (EE only)
-    if enterprise and db_version >= version.parse("3.10.5"):
+    if enterprise:
         analyzer_name = generate_analyzer_name()
         result = db.create_analyzer(analyzer_name, "geo_s2", {})
         assert result["type"] == "geo_s2"

--- a/tests/test_aql.py
+++ b/tests/test_aql.py
@@ -199,8 +199,7 @@ def test_aql_query_management(db_version, db, bad_db, col, docs):
         assert "state" in query
         assert "bind_vars" in query
         assert "runtime" in query
-        if db_version >= version.parse("3.11"):
-            assert "peak_memory_usage" in query
+        assert "peak_memory_usage" in query
     assert len(queries) == 2
 
     # Test list queries with bad database
@@ -247,7 +246,7 @@ def test_aql_query_management(db_version, db, bad_db, col, docs):
 
 
 def test_aql_query_force_one_shard_attribute_value(db, db_version, enterprise, cluster):
-    if db_version < version.parse("3.10") or not enterprise or not cluster:
+    if not enterprise or not cluster:
         return
 
     name = generate_col_name()

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2,7 +2,6 @@ import time
 import warnings
 
 import pytest
-from packaging import version
 
 from arango.errno import DATABASE_NOT_FOUND, FORBIDDEN
 from arango.exceptions import (
@@ -185,12 +184,9 @@ def test_cluster_server_count(db, bad_db, cluster):
     assert err.value.error_code in {FORBIDDEN, DATABASE_NOT_FOUND}
 
 
-def test_cluster_rebalance(sys_db, bad_db, cluster, db_version):
+def test_cluster_rebalance(sys_db, bad_db, cluster):
     if not cluster:
         pytest.skip("Only tested in a cluster setup")
-
-    if db_version < version.parse("3.10.0"):
-        pytest.skip("Only tested on ArangoDB 3.10+")
 
     # Test imbalance retrieval
     imbalance = sys_db.cluster.calculate_imbalance()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,5 +1,4 @@
 import pytest
-from packaging import version
 
 from arango.client import ArangoClient
 from arango.collection import StandardCollection
@@ -316,21 +315,15 @@ def special_db_names(sys_db):
             pass
 
 
-def test_collection_utf8(db, db_version, special_collection_names):
-    if db_version < version.parse("3.11.0"):
-        pytest.skip("UTF8 collection names require ArangoDB 3.11+")
-
+def test_collection_utf8(db, special_collection_names):
     for name in special_collection_names:
         create_and_delete_collection(db, name)
 
 
 # Not sure if this belongs in here or in `test_database.py`...
 def test_database_and_collection_utf8(
-    sys_db, db_version, special_collection_names, special_db_names
+    sys_db, special_collection_names, special_db_names
 ):
-    if db_version < version.parse("3.11.0"):
-        pytest.skip("UTF8 collection names require ArangoDB 3.11+")
-
     client = ArangoClient(hosts="http://127.0.0.1:8529")
     for db_name in special_db_names:
         username = generate_username()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 import pytest
-from packaging import version
 
 from arango.aql import AQL
 from arango.backup import Backup
@@ -416,10 +415,7 @@ def special_db_names(sys_db):
             pass
 
 
-def test_database_utf8(sys_db, db_version, special_db_names):
-    if db_version < version.parse("3.11.0"):
-        pytest.skip("UTF8 collection names require ArangoDB 3.11+")
-
+def test_database_utf8(sys_db, special_db_names):
     for name in special_db_names:
         assert sys_db.create_database(name)
         assert sys_db.has_database(name)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -220,10 +220,7 @@ def test_add_ttl_index(icol):
     icol.delete_index(result["id"])
 
 
-def test_add_inverted_index(icol, enterprise, db_version):
-    if db_version < version.parse("3.10.0"):
-        pytest.skip("Inverted indexes are not supported before 3.10.0")
-
+def test_add_inverted_index(icol, enterprise):
     parameters = dict(
         fields=[{"name": "attr1", "cache": True}],
         name="c0_cached",
@@ -234,7 +231,7 @@ def test_add_inverted_index(icol, enterprise, db_version):
     )
     expected_keys = ["primary_sort", "analyzer", "include_all_fields", "search_field"]
 
-    if enterprise and db_version >= version.parse("3.10.2"):
+    if enterprise:
         parameters["cache"] = True
         parameters["primaryKeyCache"] = True
         expected_keys.extend(["cache", "primaryKeyCache"])

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -3,11 +3,7 @@ import time
 import pytest
 from packaging import version
 
-from arango.exceptions import (
-    PregelJobCreateError,
-    PregelJobDeleteError,
-    PregelJobGetError,
-)
+from arango.exceptions import PregelJobCreateError, PregelJobDeleteError
 from tests.helpers import assert_raises, generate_string
 
 
@@ -58,13 +54,8 @@ def test_pregel_management(db, db_version, graph, cluster):
     # Test delete existing pregel job
     assert db.pregel.delete_job(job_id) is True
     time.sleep(0.2)
-    if db_version < version.parse("3.11.0"):
-        with assert_raises(PregelJobGetError) as err:
-            db.pregel.job(job_id)
-        assert err.value.error_code in {4, 10, 1600}
-    else:
-        job = db.pregel.job(job_id)
-        assert job["state"] == "canceled"
+    job = db.pregel.job(job_id)
+    assert job["state"] == "canceled"
 
     # Test delete missing pregel job
     with assert_raises(PregelJobDeleteError) as err:

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,5 +1,3 @@
-from packaging import version
-
 from arango.exceptions import (
     ViewCreateError,
     ViewDeleteError,
@@ -180,7 +178,7 @@ def test_arangosearch_view_management(db, bad_db, cluster):
     assert db.delete_view(view_name, ignore_missing=False) is True
 
 
-def test_arangosearch_view_properties(db, col, enterprise, db_version):
+def test_arangosearch_view_properties(db, col, enterprise):
     view_name = generate_view_name()
     params = {"consolidationIntervalMsec": 50000}
 
@@ -199,10 +197,8 @@ def test_arangosearch_view_properties(db, col, enterprise, db_version):
             }
         )
 
-        if db_version >= version.parse("3.9.6"):
-            params.update({"primarySortCache": True, "primaryKeyCache": True})
-        if db_version >= version.parse("3.10.3"):
-            params.update({"storedValues": ["attr1", "attr2"]})
+        params.update({"primarySortCache": True, "primaryKeyCache": True})
+        params.update({"storedValues": ["attr1", "attr2"]})
 
     result = db.create_arangosearch_view(view_name, properties=params)
     assert "id" in result


### PR DESCRIPTION
- Drop `3.10` from arangodb matrix
- Remove patch version from `3.11`
- First CI run with `latest` == `3.12`
- Doc updates
- Removal of 3.10 & 3.11 checks in the tests