### PR TITLE
fix: `ServerConnectionError`

### DIFF
--- a/arango/client.py
+++ b/arango/client.py
@@ -12,7 +12,7 @@ from arango.connection import (
     JwtSuperuserConnection,
 )
 from arango.database import StandardDatabase
-from arango.exceptions import ServerConnectionError
+from arango.exceptions import ArangoClientError, ServerConnectionError
 from arango.http import (
     DEFAULT_REQUEST_TIMEOUT,
     DefaultHTTPClient,
@@ -300,6 +300,6 @@ class ArangoClient:
             except ServerConnectionError as err:
                 raise err
             except Exception as err:
-                raise ServerConnectionError(f"bad connection: {err}")
+                raise ArangoClientError(f"bad connection: {err}")
 
         return StandardDatabase(connection)

--- a/arango/connection.py
+++ b/arango/connection.py
@@ -226,9 +226,13 @@ class BaseConnection:
         request = Request(method="get", endpoint="/_api/collection")
         resp = self.send_request(request)
         if resp.status_code in {401, 403}:
-            raise ServerConnectionError("bad username/password or token is expired")
+            raise ServerConnectionError(
+                resp, request, "bad username/password or token is expired"
+            )
         if not resp.is_success:  # pragma: no cover
-            raise ServerConnectionError(resp.error_message or "bad server response")
+            raise ServerConnectionError(
+                resp, request, resp.error_message or "bad server response"
+            )
         return resp.status_code
 
     @abstractmethod

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -614,7 +614,7 @@ class PregelJobDeleteError(ArangoServerError):
 #####################
 
 
-class ServerConnectionError(ArangoClientError):
+class ServerConnectionError(ArangoServerError):
     """Failed to connect to ArangoDB server."""
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from requests import Session
 
 from arango.client import ArangoClient
 from arango.database import StandardDatabase
-from arango.exceptions import ServerConnectionError
+from arango.exceptions import ArangoClientError, ServerConnectionError
 from arango.http import DefaultHTTPClient, DeflateRequestCompression
 from arango.resolver import FallbackHostResolver, RandomHostResolver, SingleHostResolver
 from tests.helpers import (
@@ -89,7 +89,7 @@ def test_client_bad_connection(db, username, password, cluster):
 
     # Test connection with invalid host URL
     client = ArangoClient(hosts="http://127.0.0.1:8500")
-    with pytest.raises(ServerConnectionError) as err:
+    with pytest.raises(ArangoClientError) as err:
         client.db(db.name, username, password, verify=True)
     assert "bad connection" in str(err.value)
 


### PR DESCRIPTION
Updates the `ServerConnectionError` exception to inherit from `ArangoServerError ` instead of `ArangoClientError`, thereby giving us access to `error_code`, among other things.


Previously, the following code would just return the error message:

```py
from arango import ArangoClient
db = ArangoClient().db("bad_db", password="test", verify=True)
```

Whereas now we have access to the error code (i.e `1228`) 