### PR TITLE
Config file selection

### DIFF
--- a/starter.sh
+++ b/starter.sh
@@ -34,8 +34,10 @@ fi
 
 if [ "$version" == "latest" ]; then
     conf_file="${setup}-3.12"
+elif [[ "$version" == *.*.* ]]; then
+    conf_file="${setup}-${version%.*}"
 else
-    conf_file="${setup}-${version%.*.*}"
+    conf_file="${setup}-${version}"
 fi
 
 docker run -d \


### PR DESCRIPTION
The selection works as follows

- "latest" => 3.12
- full version specified, using two dots, say "3.12.0" => 3.12
- otherwise, assuming we're using only one do, say "3.12" => 3.12