### PR TITLE
Fix collection test

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -209,7 +209,6 @@ def test_collection_management(db, bad_db, cluster):
         shard_count=2,
         shard_fields=["test_attr:"],
         replication_factor=1,
-        shard_like="",
         sync_replication=False,
         enforce_replication_factor=False,
         sharding_strategy="community-compat",
@@ -235,6 +234,14 @@ def test_collection_management(db, bad_db, cluster):
     assert properties["system"] is False
     assert properties["computedValues"] == computed_values
     col.configure(computed_values=[])
+
+    if cluster:
+        # Create distribute-shards-like collection
+        shard_like_name = col_name + "_shards_like"
+        shard_like_col = db.create_collection(name=shard_like_name, shard_like=col_name)
+        assert shard_like_col.properties()["shard_like"] == col_name
+        assert db.has_collection(shard_like_name) is True
+        assert db.delete_collection(shard_like_name, system=False) is True
 
     # Test create duplicate collection
     with assert_raises(CollectionCreateError) as err:


### PR DESCRIPTION
`test_collection.py::test_collection_management` now fails due to `arango.exceptions.CollectionCreateError: [HTTP 400][ERR 10] Value cannot be empty. on attribute distributeShardsLike`. This happens because the `shard_like` parameter is empty. Truth be told, that was never a valid configuration, but since 3.12 the validation got better and now we're actually throwing an exception.

This PR removes the empty value and adds proper testing for the `shard_like` parameter.

With that, all *cluster* tests should turn green. 