### PR TITLE
Increasing size limit for transactions

### DIFF
--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -97,7 +97,7 @@ def test_transaction_commit(db, col, docs):
         sync=True,
         allow_implicit=False,
         lock_timeout=1000,
-        max_size=10000,
+        max_size=1024 * 1024,  # 1MB
     )
     txn_col = txn_db.collection(col.name)
 
@@ -126,7 +126,7 @@ def test_transaction_fetch_existing(db, col, docs):
         sync=True,
         allow_implicit=False,
         lock_timeout=1000,
-        max_size=10000,
+        max_size=1024 * 1024,  # 1MB
     )
     txn_col = original_txn.collection(col.name)
 


### PR DESCRIPTION
We've had some issues with the transactions tests. After [digging a little deeper](https://github.com/arangodb/arangodb/pull/20874), I found out it was not the driver's fault.

This PR increases the transaction size limit to 1KB, so we should be safe from now on.

It should conclude the quest of making 3.12 builds green.