### PR TITLE
DE-819 | bring back `REQUEST_TIMEOUT` as a class attribute

### DIFF
--- a/arango/http.py
+++ b/arango/http.py
@@ -154,9 +154,11 @@ class DefaultHTTPClient(HTTPClient):
     :type pool_timeout: int | float | None
     """
 
+    REQUEST_TIMEOUT = DEFAULT_REQUEST_TIMEOUT
+
     def __init__(
         self,
-        request_timeout: Union[int, float, None] = DEFAULT_REQUEST_TIMEOUT,
+        request_timeout: Union[int, float, None] = REQUEST_TIMEOUT,
         retry_attempts: int = 3,
         backoff_factor: float = 1.0,
         pool_connections: int = 10,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,6 +110,31 @@ def test_client_http_client_attributes(db, username, password):
     assert http_client.request_timeout == 80
     assert client.request_timeout == http_client.request_timeout
 
+    client_no_timeout = ArangoClient(
+        hosts="http://127.0.0.1:8529", request_timeout=None
+    )
+
+    assert client_no_timeout.request_timeout is None
+
+    client_no_timeout = ArangoClient(
+        hosts="http://127.0.0.1:8529",
+        http_client=DefaultHTTPClient(request_timeout=None),
+    )
+
+    assert client_no_timeout.request_timeout is None
+
+    class NoTimeoutHTTPClient(DefaultHTTPClient):
+        REQUEST_TIMEOUT = None
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(request_timeout=self.REQUEST_TIMEOUT, *args, **kwargs)
+
+    client_no_timeout = ArangoClient(
+        hosts="http://127.0.0.1:8529", http_client=NoTimeoutHTTPClient()
+    )
+
+    assert client_no_timeout.request_timeout is None
+
 
 def test_client_custom_http_client(db, username, password):
     # Define custom HTTP client which increments the counter on any API call.


### PR DESCRIPTION
[Optional PR]

Unfortunately [this](https://github.com/arangodb/python-arango/issues/170#issuecomment-886861778) is no longer supported, but we can achieve something similar with this PR (see the added test cases)

Current ways that we support setting `request_timeout`:

```py
# 1
client_no_timeout = ArangoClient(request_timeout=None)

# 2
client_no_timeout = ArangoClient(http_client=DefaultHTTPClient(request_timeout=None))

# 3
class NoTimeoutHTTPClient(DefaultHTTPClient):
    REQUEST_TIMEOUT = None

    def __init__(self, *args, **kwargs):
        super().__init__(request_timeout=self.REQUEST_TIMEOUT, *args, **kwargs)

client_no_timeout = ArangoClient(http_client=NoTimeoutHTTPClient())
```