### PR TITLE
RTD update

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -98,5 +98,6 @@ jobs:
       - name: Run Sphinx doctest
         run: python -m sphinx -b doctest docs docs/_build
 
-      - name: Generate Sphinx HTML
-        run: python -m sphinx -b html -W docs docs/_build
+      # No longer needed as this is handled by Read the Docs
+      #- name: Generate Sphinx HTML
+      #  run: python -m sphinx -b html -W docs docs/_build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,7 @@ sphinx:
   configuration: docs/conf.py
   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
   # builder: "dirhtml"
+  builder: html
   # Fail on all warnings to avoid broken references
   fail_on_warning: true
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  commands:
+    - python -m sphinx -b html -W docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  commands:
-    - python -m sphinx -b html -W docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/arango/request.py
+++ b/arango/request.py
@@ -12,7 +12,7 @@ def normalize_headers(
     if driver_flags is not None:
         for flag in driver_flags:
             flags = flags + flag + ";"
-    driver_version = "9.0.0"
+    driver_version = "8.1.0"
     driver_header = "python-arango/" + driver_version + " (" + flags + ")"
     normalized_headers: Headers = {
         "charset": "utf-8",

--- a/arango/request.py
+++ b/arango/request.py
@@ -12,7 +12,7 @@ def normalize_headers(
     if driver_flags is not None:
         for flag in driver_flags:
             flags = flags + flag + ";"
-    driver_version = "7.7.0"
+    driver_version = "9.0.0"
     driver_header = "python-arango/" + driver_version + " (" + flags + ")"
     normalized_headers: Headers = {
         "charset": "utf-8",

--- a/arango/request.py
+++ b/arango/request.py
@@ -12,7 +12,7 @@ def normalize_headers(
     if driver_flags is not None:
         for flag in driver_flags:
             flags = flags + flag + ";"
-    driver_version = "9.0.1"
+    driver_version = "9.0.0"
     driver_header = "python-arango/" + driver_version + " (" + flags + ")"
     normalized_headers: Headers = {
         "charset": "utf-8",

--- a/arango/request.py
+++ b/arango/request.py
@@ -12,7 +12,7 @@ def normalize_headers(
     if driver_flags is not None:
         for flag in driver_flags:
             flags = flags + flag + ";"
-    driver_version = "9.0.0"
+    driver_version = "9.0.1"
     driver_header = "python-arango/" + driver_version + " (" + flags + ")"
     normalized_headers: Headers = {
         "charset": "utf-8",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,9 @@ html_static_path = ["static"]
 html_theme = "sphinx_rtd_theme"
 master_doc = "index"
 
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "docs.python-arango.com")
+
 autodoc_member_order = "bysource"
 
 doctest_global_setup = """


### PR DESCRIPTION
Removal of Sphinx context injection at build time has little effect for us.
Read [the blog post](https://about.readthedocs.com/blog/2024/07/addons-by-default/) from Read The Docs for more information.

However, this PR also updates the way docs are being build:
- We're using RTD build hook, which adds a new check for every PR (named docs/readthedocs.org:python-driver-for-arangodb). This comes with the park that we can now easily view the documentation build for every PR by clicking on details (a fake documentation page is generated).
- The docs action is not needed to build the documentation anymore. However, we'll keep it around for now in order to run the docs tests.

