### PR TITLE
Integrate latest 3.12.1 changes

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -52,6 +52,7 @@ from arango.exceptions import (
     ServerLicenseGetError,
     ServerLicenseSetError,
     ServerLogLevelError,
+    ServerLogLevelResetError,
     ServerLogLevelSetError,
     ServerLogSettingError,
     ServerLogSettingSetError,
@@ -998,6 +999,35 @@ class Database(ApiGroup):
         def response_handler(resp: Response) -> Json:
             if not resp.is_success:
                 raise ServerLogLevelSetError(resp, request)
+            result: Json = resp.body
+            return result
+
+        return self._execute(request, response_handler)
+
+    def reset_log_levels(self, server_id: Optional[str] = None) -> Result[Json]:
+        """Reset the logging levels.
+
+        Revert the server’s log level settings to the values they had at startup,
+        as determined by the startup options specified on the command-line,
+        a configuration file, and the factory defaults.
+
+        :param server_id: Forward log level to a specific server. This makes it
+            easier to adjust the log levels in clusters because DB-Servers require
+            JWT authentication whereas Coordinators also support authentication
+            using usernames and passwords.
+        :type server_id: str | None
+        :return: New logging levels.
+        :rtype: dict
+        """
+        params: Params = {}
+        if server_id is not None:
+            params["serverId"] = server_id
+
+        request = Request(method="delete", endpoint="/_admin/log/level", params=params)
+
+        def response_handler(resp: Response) -> Json:
+            if not resp.is_success:
+                raise ServerLogLevelResetError(resp, request)
             result: Json = resp.body
             return result
 

--- a/arango/database.py
+++ b/arango/database.py
@@ -3020,6 +3020,7 @@ class StandardDatabase(Database):
         allow_implicit: Optional[bool] = None,
         lock_timeout: Optional[int] = None,
         max_size: Optional[int] = None,
+        skip_fast_lock_round: Optional[bool] = None,
     ) -> "TransactionDatabase":
         """Begin a transaction.
 
@@ -3043,6 +3044,9 @@ class StandardDatabase(Database):
         :type lock_timeout: int | None
         :param max_size: Max transaction size in bytes.
         :type max_size: int | None
+        :param skip_fast_lock_round: Whether to disable fast locking for write
+            operations.
+        :type skip_fast_lock_round: bool | None
         :return: Database API wrapper object specifically for transactions.
         :rtype: arango.database.TransactionDatabase
         """
@@ -3055,6 +3059,7 @@ class StandardDatabase(Database):
             allow_implicit=allow_implicit,
             lock_timeout=lock_timeout,
             max_size=max_size,
+            skip_fast_lock_round=skip_fast_lock_round,
         )
 
     def begin_controlled_execution(
@@ -3191,6 +3196,8 @@ class TransactionDatabase(Database):
     :param transaction_id: Initialize using an existing transaction instead of creating
         a new transaction.
     :type transaction_id: str | None
+    :param skip_fast_lock_round: Whether to disable fast locking for write operations.
+    :type skip_fast_lock_round: bool | None
     """
 
     def __init__(
@@ -3204,6 +3211,7 @@ class TransactionDatabase(Database):
         lock_timeout: Optional[int] = None,
         max_size: Optional[int] = None,
         transaction_id: Optional[str] = None,
+        skip_fast_lock_round: Optional[bool] = False,
     ) -> None:
         self._executor: TransactionApiExecutor
         super().__init__(
@@ -3218,6 +3226,7 @@ class TransactionDatabase(Database):
                 lock_timeout=lock_timeout,
                 max_size=max_size,
                 transaction_id=transaction_id,
+                skip_fast_lock_round=skip_fast_lock_round,
             ),
         )
 

--- a/arango/database.py
+++ b/arango/database.py
@@ -3241,7 +3241,7 @@ class TransactionDatabase(Database):
         lock_timeout: Optional[int] = None,
         max_size: Optional[int] = None,
         transaction_id: Optional[str] = None,
-        skip_fast_lock_round: Optional[bool] = False,
+        skip_fast_lock_round: Optional[bool] = None,
     ) -> None:
         self._executor: TransactionApiExecutor
         super().__init__(

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -674,6 +674,10 @@ class ServerLogLevelError(ArangoServerError):
     """Failed to retrieve server log levels."""
 
 
+class ServerLogLevelResetError(ArangoServerError):
+    """Failed to reset server log levels."""
+
+
 class ServerLogSettingError(ArangoServerError):
     """Failed to retrieve server log settings."""
 

--- a/arango/executor.py
+++ b/arango/executor.py
@@ -261,7 +261,7 @@ class TransactionApiExecutor:
         max_size: Optional[int] = None,
         allow_dirty_read: bool = False,
         transaction_id: Optional[str] = None,
-        skip_fast_lock_round: Optional[bool] = False,
+        skip_fast_lock_round: Optional[bool] = None,
     ) -> None:
         self._conn = connection
 

--- a/arango/executor.py
+++ b/arango/executor.py
@@ -245,6 +245,8 @@ class TransactionApiExecutor:
     :param transaction_id: Initialize using an existing transaction instead of starting
         a new transaction.
     :type transaction_id: str | None
+    :param skip_fast_lock_round: Whether to disable fast locking for write operations.
+    :type skip_fast_lock_round: bool | None
     """
 
     def __init__(
@@ -259,6 +261,7 @@ class TransactionApiExecutor:
         max_size: Optional[int] = None,
         allow_dirty_read: bool = False,
         transaction_id: Optional[str] = None,
+        skip_fast_lock_round: Optional[bool] = False,
     ) -> None:
         self._conn = connection
 
@@ -279,6 +282,8 @@ class TransactionApiExecutor:
             data["lockTimeout"] = lock_timeout
         if max_size is not None:
             data["maxTransactionSize"] = max_size
+        if skip_fast_lock_round is not None:
+            data["skipFastLockRound"] = skip_fast_lock_round
 
         if transaction_id is None:
             request = Request(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dev = [
     "pytest-cov>=3.0.0",
     "sphinx",
     "sphinx_rtd_theme",
-    "types-pkg_resources",
     "types-requests",
     "types-setuptools",
 ]

--- a/starter.sh
+++ b/starter.sh
@@ -6,7 +6,7 @@
 # Usage:
 #   ./starter.sh [single|cluster] [community|enterprise] [version]
 # Example:
-#   ./starter.sh cluster enterprise 3.11.4
+#   ./starter.sh cluster enterprise 3.12.1
 
 setup="${1:-single}"
 license="${2:-community}"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -24,6 +24,7 @@ from arango.exceptions import (
     ServerEngineError,
     ServerLicenseSetError,
     ServerLogLevelError,
+    ServerLogLevelResetError,
     ServerLogLevelSetError,
     ServerMetricsError,
     ServerModeSetError,
@@ -65,7 +66,7 @@ def test_database_attributes(db, username):
     assert isinstance(db.wal, WAL)
 
 
-def test_database_misc_methods(client, sys_db, db, bad_db, cluster, secret):
+def test_database_misc_methods(client, sys_db, db, bad_db, cluster, secret, db_version):
     # Test get properties
     properties = db.properties()
     assert "id" in properties
@@ -249,7 +250,8 @@ def test_database_misc_methods(client, sys_db, db, bad_db, cluster, secret):
     assert err.value.error_code in {11, 1228}
 
     # Test get log levels
-    assert isinstance(sys_db.log_levels(), dict)
+    default_log_levels = sys_db.log_levels()
+    assert isinstance(default_log_levels, dict)
 
     # Test get log levels with bad database
     with assert_raises(ServerLogLevelError) as err:
@@ -295,6 +297,13 @@ def test_database_misc_methods(client, sys_db, db, bad_db, cluster, secret):
     assert "url" in result_1
     assert "username" not in result_1
     assert result_1 == result_2
+
+    # Reset Log Settings
+    if db.version() >= "3.12.1":
+        result = sys_db.reset_log_levels()
+        assert result == default_log_levels
+        with assert_raises(ServerLogLevelResetError):
+            bad_db.reset_log_levels()
 
     # Test get storage engine
     engine = db.engine()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -300,6 +300,10 @@ def test_database_misc_methods(client, sys_db, db, bad_db, cluster, secret, db_v
 
     # Reset Log Settings
     if db.version() >= "3.12.1":
+        if cluster:
+            server_id = sys_db.cluster.server_id()
+            assert isinstance(sys_db.reset_log_levels(server_id), dict)
+
         result = sys_db.reset_log_levels()
         assert result == default_log_levels
         with assert_raises(ServerLogLevelResetError):


### PR DESCRIPTION
This PR integrates the following changes made in 3.12.1:
- new `skipFastLockRound` option for transactions (see [docs](https://docs.arangodb.com/3.13/develop/http-api/transactions/stream-transactions/#begin-a-stream-transaction_body_skipFastLockRound))
- new REST API endpoint HTTP DELETE `/_admin/log/level` to reset all log
  levels to their startup values (see [docs](https://docs.arangodb.com/3.13/develop/http-api/monitoring/logs/#reset-the-server-log-levels))

Driver version 8.1.0 is prepared. Once this PR is merged, I'll proceed with the release.