### PR TITLE
Integrate latest 3.12.2 changes

### DIFF
--- a/arango/cluster.py
+++ b/arango/cluster.py
@@ -15,6 +15,7 @@ from arango.exceptions import (
     ClusterServerRoleError,
     ClusterServerStatisticsError,
     ClusterServerVersionError,
+    ClusterVpackSortMigrationError,
 )
 from arango.formatter import format_body
 from arango.request import Request
@@ -441,6 +442,60 @@ class Cluster(ApiGroup):  # pragma: no cover
             if not resp.is_success:
                 raise ClusterRebalanceError(resp, request)
             result: bool = resp.body["code"] == 202
+            return result
+
+        return self._execute(request, response_handler)
+
+    def vpack_sort_migration_status(self) -> Result[Json]:
+        """Query the status of the vpack sorting migration.
+
+        :return: Status of the VPack sort migration.
+        :rtype: dict
+        """
+        request = Request(
+            method="get", endpoint="/_admin/cluster/vpackSortMigration/status"
+        )
+
+        def response_handler(resp: Response) -> Json:
+            if not resp.is_success:
+                raise ClusterVpackSortMigrationError(resp, request)
+            result: Json = resp.body["result"]
+            return result
+
+        return self._execute(request, response_handler)
+
+    def vpack_sort_migration_index_check(self) -> Result[Json]:
+        """Check for indexes impacted by the sorting behavior before 3.12.2.
+
+        :return: Status of indexes.
+        :rtype: dict
+        """
+        request = Request(
+            method="get", endpoint="/_admin/cluster/vpackSortMigration/check"
+        )
+
+        def response_handler(resp: Response) -> Json:
+            if not resp.is_success:
+                raise ClusterVpackSortMigrationError(resp, request)
+            result: Json = resp.body["result"]
+            return result
+
+        return self._execute(request, response_handler)
+
+    def migrate_vpack_sorting(self) -> Result[Json]:
+        """Migrate instances to the new VPack sorting behavior.
+
+        :return: Status of the VPack sort migration.
+        :rtype: dict
+        """
+        request = Request(
+            method="put", endpoint="/_admin/cluster/vpackSortMigration/migrate"
+        )
+
+        def response_handler(resp: Response) -> Json:
+            if not resp.is_success:
+                raise ClusterVpackSortMigrationError(resp, request)
+            result: Json = resp.body["result"]
             return result
 
         return self._execute(request, response_handler)

--- a/arango/database.py
+++ b/arango/database.py
@@ -935,7 +935,9 @@ class Database(ApiGroup):
 
         return self._execute(request, response_handler)
 
-    def log_levels(self, server_id: Optional[str] = None) -> Result[Json]:
+    def log_levels(
+        self, server_id: Optional[str] = None, with_appenders: Optional[bool] = None
+    ) -> Result[Json]:
         """Return current logging levels.
 
         :param server_id: Forward log level to a specific server. This makes it
@@ -943,12 +945,16 @@ class Database(ApiGroup):
             JWT authentication whereas Coordinators also support authentication
             using usernames and passwords.
         :type server_id: str
+        :param with_appenders: Include appenders in the response.
+        :type with_appenders: bool
         :return: Current logging levels.
         :rtype: dict
         """
         params: Params = {}
         if server_id is not None:
             params["serverId"] = server_id
+        if with_appenders is not None:
+            params["withAppenders"] = with_appenders
 
         request = Request(method="get", endpoint="/_admin/log/level", params=params)
 
@@ -961,7 +967,10 @@ class Database(ApiGroup):
         return self._execute(request, response_handler)
 
     def set_log_levels(
-        self, server_id: Optional[str] = None, **kwargs: Dict[str, Any]
+        self,
+        server_id: Optional[str] = None,
+        with_appenders: Optional[bool] = None,
+        **kwargs: Dict[str, Any],
     ) -> Result[Json]:
         """Set the logging levels.
 
@@ -983,6 +992,8 @@ class Database(ApiGroup):
             JWT authentication whereas Coordinators also support authentication
             using usernames and passwords.
         :type server_id: str | None
+        :param with_appenders: Include appenders in the request.
+        :type with_appenders: bool | None
         :param kwargs: Logging levels.
         :type kwargs: Dict[str, Any]
         :return: New logging levels.
@@ -991,6 +1002,8 @@ class Database(ApiGroup):
         params: Params = {}
         if server_id is not None:
             params["serverId"] = server_id
+        if with_appenders is not None:
+            params["withAppenders"] = with_appenders
 
         request = Request(
             method="put", endpoint="/_admin/log/level", params=params, data=kwargs

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -1047,6 +1047,10 @@ class ClusterRebalanceError(ArangoServerError):
     """Failed to execute cluster re-balancing operation (load/set)."""
 
 
+class ClusterVpackSortMigrationError(ArangoServerError):
+    """Failed to execute vpack sort migration request."""
+
+
 ##################
 # JWT Exceptions #
 ##################

--- a/arango/formatter.py
+++ b/arango/formatter.py
@@ -365,6 +365,12 @@ def format_aql_query(body: Json) -> Json:
     # New in 3.11
     if "peakMemoryUsage" in body:
         result["peak_memory_usage"] = body["peakMemoryUsage"]
+
+    # New in 3.12.2
+    if "modificationQuery" in body:
+        result["modification_query"] = body["modificationQuery"]
+    if "warnings" in body:
+        result["warnings"] = body["warnings"]
     return verify_format(body, result)
 
 

--- a/arango/request.py
+++ b/arango/request.py
@@ -12,7 +12,7 @@ def normalize_headers(
     if driver_flags is not None:
         for flag in driver_flags:
             flags = flags + flag + ";"
-    driver_version = "8.1.0"
+    driver_version = "8.1.1"
     driver_header = "python-arango/" + driver_version + " (" + flags + ")"
     normalized_headers: Headers = {
         "charset": "utf-8",

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -60,7 +60,7 @@ database.
     # Set the log .
     sys_db.set_log_levels(
         agency='DEBUG',
-        collector='INFO',
+        deprecation='INFO',
         threads='WARNING'
     )
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -99,8 +99,8 @@ def test_database_misc_methods(client, sys_db, db, bad_db, cluster, secret, db_v
     assert err.value.error_code in {11, 1228}
 
     # Test get server required database version
-    version = db.required_db_version()
-    assert isinstance(version, str)
+    required_version = db.required_db_version()
+    assert isinstance(required_version, str)
 
     # Test get server target version with bad database
     with assert_raises(ServerRequiredDBVersionError):
@@ -252,6 +252,9 @@ def test_database_misc_methods(client, sys_db, db, bad_db, cluster, secret, db_v
     # Test get log levels
     default_log_levels = sys_db.log_levels()
     assert isinstance(default_log_levels, dict)
+    if db_version >= version.parse("3.12.2"):
+        log_levels_with_appenders = sys_db.log_levels(with_appenders=True)
+        assert isinstance(log_levels_with_appenders, dict)
 
     # Test get log levels with bad database
     with assert_raises(ServerLogLevelError) as err:


### PR DESCRIPTION
* Add API GET `/_admin/cluster/vpackSortMigration/status` to query the status of the vpack sorting migration on dbservers, single servers and coordinators.
* The `_admin/log/level` endpoint has also been extended to with an optional
  parameter `withAppenders`.
* There is also a migration API under GET `/_admin/cluster/vpackSortMigration/check` and PUT `/_admin/cluster/vpackSortMigration/migrate` to check for problematic indexes and - provided there are none - to migrate the instance to the new sorting order.