### PR TITLE
Fix docstring

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -1284,8 +1284,9 @@ class Database(ApiGroup):
         :type name: str
         :param users: List of users with access to the new database, where each
             user is a dictionary with fields "username", "password", "active"
-            and "extra" (see below for example). If not set, only the admin and
-            current user are granted access.
+            and "extra" (see below for example). If not set, the default user root
+            will be used to ensure that the new database will be accessible after
+            it is created.
         :type users: [dict]
         :param replication_factor: Default replication factor for collections
             created in this database. Special values include "satellite" which


### PR DESCRIPTION
Fixing the `users` parameter docstring for the `Database.create_database` function.
The [official documentation](https://docs.arangodb.com/stable/develop/http-api/databases/#create-a-database_body_users) states that only the root user will be added by default, if no users are specified.
The docstring is incorect because it claims that also the "current user" is included.