### PR TITLE
License Parameter Docstring

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -436,7 +436,7 @@ class Database(ApiGroup):
         instance. Can be called on single servers, Coordinators,
         and DB-Servers.
 
-        :param license: The Base64-encoded license string.
+        :param license: The Base64-encoded license string, wrapped in double-quotes.
         :type license: str
         :param force: If set to True, the new license will be set even if
             it expires sooner than the current license.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -454,7 +454,7 @@ def test_license(sys_db, enterprise):
     else:
         assert license == {"license": "none"}
         with pytest.raises(ServerLicenseSetError):
-            sys_db.set_license("abc")
+            sys_db.set_license('"abc"')
 
 
 def test_options(sys_db, db_version):


### PR DESCRIPTION
The license has to be a Base64-encoded string wrapped in double quotes.

See https://docs.arangodb.com/stable/develop/http-api/administration/#set-a-new-license