### PR TITLE
update `collection.find` to support nested fields

### DIFF
--- a/arango/utils.py
+++ b/arango/utils.py
@@ -120,5 +120,9 @@ def build_filter_conditions(filters: Json) -> str:
     if not filters:
         return ""
 
-    conditions = [f"doc.`{k}` == {json.dumps(v)}" for k, v in filters.items()]
+    conditions = []
+    for k, v in filters.items():
+        field = k if "." in k else f"`{k}`"
+        conditions.append(f"doc.{field} == {json.dumps(v)}")
+
     return "FILTER " + " AND ".join(conditions)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1241,6 +1241,10 @@ def test_document_find(col, bad_col, docs):
     col.insert({"foo bar": "baz"})
     assert len(list(col.find({"foo bar": "baz"}))) == 1
 
+    # Test find by nested attribute
+    col.insert({"foo": {"bar": "baz"}})
+    assert len(list(col.find({"foo.bar": "baz"}))) == 1
+
 
 def test_document_find_near(col, bad_col, docs):
     col.import_bulk(docs)


### PR DESCRIPTION
`db.collection().find(...)` was previously not working for nested fields

Happy to go with an alternative solution if there's an easier way