### PR TITLE
Removing "cancelled" response

### DIFF
--- a/arango/job.py
+++ b/arango/job.py
@@ -60,8 +60,7 @@ class AsyncJob(Generic[T]):
         fail.
 
         :return: Async job status. Possible values are "pending" (job is still
-            in queue), "done" (job finished or raised an error), or "cancelled"
-            (job was cancelled before completion).
+            in queue), "done" (job finished or raised an error).
         :rtype: str
         :raise arango.exceptions.AsyncJobStatusError: If retrieval fails.
         """

--- a/arango/job.py
+++ b/arango/job.py
@@ -62,7 +62,8 @@ class AsyncJob(Generic[T]):
         :return: Async job status. Possible values are "pending" (job is still
             in queue), "done" (job finished or raised an error).
         :rtype: str
-        :raise arango.exceptions.AsyncJobStatusError: If retrieval fails.
+        :raise arango.exceptions.AsyncJobStatusError: If retrieval fails or
+            job is not found.
         """
         request = Request(method="get", endpoint=f"/_api/job/{self._id}")
         resp = self._conn.send_request(request)

--- a/docs/async.rst
+++ b/docs/async.rst
@@ -45,8 +45,8 @@ the results can be retrieved once available via :ref:`AsyncJob` objects.
 
     # Retrieve the status of each async job.
     for job in [job1, job2, job3, job4]:
-        # Job status can be "pending", "done" or "cancelled".
-        assert job.status() in {'pending', 'done', 'cancelled'}
+        # Job status can be "pending" or "done".
+        assert job.status() in {'pending', 'done'}
 
         # Let's wait until the jobs are finished.
         while job.status() != 'done':


### PR DESCRIPTION
The documentation incorrectly states that the `status()` of an `AsyncJob` could have the value "cancelled". If you look at the implementation, the method may only return "pending" or "done". In all other cases, it raises an error.

Hence, we should not mention it.