### PR TITLE
Collection Maintenance

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -574,6 +574,7 @@ class Collection(ApiGroup):
         """Delete all documents in the collection.
 
         :param sync: Block until deletion operation is synchronized to disk.
+        :type sync: bool | None
         :param compact: Whether to compact the collection after truncation.
         :return: True if collection was truncated successfully.
         :rtype: bool

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -2771,7 +2771,6 @@ class StandardCollection(Collection):
             "returnNew": return_new,
             "returnOld": return_old,
             "ignoreRevs": not check_rev,
-            "overwrite": not check_rev,
             "silent": silent,
         }
         if sync is not None:

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -576,6 +576,7 @@ class Collection(ApiGroup):
         :param sync: Block until deletion operation is synchronized to disk.
         :type sync: bool | None
         :param compact: Whether to compact the collection after truncation.
+        :type compact: bool | None
         :return: True if collection was truncated successfully.
         :rtype: bool
         :raise arango.exceptions.CollectionTruncateError: If operation fails.

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -1761,14 +1761,6 @@ class Collection(ApiGroup):
             successfully (returns document metadata) and which were not
             (returns exception object).
 
-        .. note::
-
-            In edge/vertex collections, this method does NOT provide the
-            transactional guarantees and validations that single insert
-            operation does for graphs. If these properties are required, see
-            :func:`arango.database.StandardDatabase.begin_batch_execution`
-            for an alternative approach.
-
         :param documents: List of new documents to insert. If they contain the
             "_key" or "_id" fields, the values are used as the keys of the new
             documents (auto-generated otherwise). Any "_rev" field is ignored.
@@ -1890,14 +1882,6 @@ class Collection(ApiGroup):
             (returns exception object). Alternatively, you can rely on
             setting **raise_on_document_error** to True (defaults to False).
 
-        .. note::
-
-            In edge/vertex collections, this method does NOT provide the
-            transactional guarantees and validations that single update
-            operation does for graphs. If these properties are required, see
-            :func:`arango.database.StandardDatabase.begin_batch_execution`
-            for an alternative approach.
-
         :param documents: Partial or full documents with the updated values.
             They must contain the "_id" or "_key" fields.
         :type documents: [dict]
@@ -2009,14 +1993,6 @@ class Collection(ApiGroup):
     ) -> Result[int]:
         """Update matching documents.
 
-        .. note::
-
-            In edge/vertex collections, this method does NOT provide the
-            transactional guarantees and validations that single update
-            operation does for graphs. If these properties are required, see
-            :func:`arango.database.StandardDatabase.begin_batch_execution`
-            for an alternative approach.
-
         :param filters: Document filters.
         :type filters: dict
         :param body: Full or partial document body with the updates.
@@ -2098,14 +2074,6 @@ class Collection(ApiGroup):
             inspect the list to determine which documents were replaced
             successfully (returns document metadata) and which were not
             (returns exception object).
-
-        .. note::
-
-            In edge/vertex collections, this method does NOT provide the
-            transactional guarantees and validations that single replace
-            operation does for graphs. If these properties are required, see
-            :func:`arango.database.StandardDatabase.begin_batch_execution`
-            for an alternative approach.
 
         :param documents: New documents to replace the old ones with. They must
             contain the "_id" or "_key" fields. Edge documents must also have
@@ -2201,14 +2169,6 @@ class Collection(ApiGroup):
     ) -> Result[int]:
         """Replace matching documents.
 
-        .. note::
-
-            In edge/vertex collections, this method does NOT provide the
-            transactional guarantees and validations that single replace
-            operation does for graphs. If these properties are required, see
-            :func:`arango.database.StandardDatabase.begin_batch_execution`
-            for an alternative approach.
-
         :param filters: Document filters.
         :type filters: dict
         :param body: New document body.
@@ -2276,14 +2236,6 @@ class Collection(ApiGroup):
             inspect the list to determine which documents were deleted
             successfully (returns document metadata) and which were not
             (returns exception object).
-
-        .. note::
-
-            In edge/vertex collections, this method does NOT provide the
-            transactional guarantees and validations that single delete
-            operation does for graphs. If these properties are required, see
-            :func:`arango.database.StandardDatabase.begin_batch_execution`
-            for an alternative approach.
 
         :param documents: Document IDs, keys or bodies. Document bodies must
             contain the "_id" or "_key" fields.
@@ -2368,14 +2320,6 @@ class Collection(ApiGroup):
     ) -> Result[int]:
         """Delete matching documents.
 
-        .. note::
-
-            In edge/vertex collections, this method does NOT provide the
-            transactional guarantees and validations that single delete
-            operation does for graphs. If these properties are required, see
-            :func:`arango.database.StandardDatabase.begin_batch_execution`
-            for an alternative approach.
-
         :param filters: Document filters.
         :type filters: dict
         :param limit: Max number of documents to delete. If the limit is lower
@@ -2441,14 +2385,6 @@ class Collection(ApiGroup):
 
             This method is faster than :func:`arango.collection.Collection.insert_many`
             but does not return as many details.
-
-        .. note::
-
-            In edge/vertex collections, this method does NOT provide the
-            transactional guarantees and validations that single insert
-            operation does for graphs. If these properties are required, see
-            :func:`arango.database.StandardDatabase.begin_batch_execution`
-            for an alternative approach.
 
         :param documents: List of new documents to insert. If they contain the
             "_key" or "_id" fields, the values are used as the keys of the new

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -566,15 +566,29 @@ class Collection(ApiGroup):
 
         return self._execute(request, response_handler)
 
-    def truncate(self) -> Result[bool]:
+    def truncate(
+        self,
+        sync: Optional[bool] = None,
+        compact: Optional[bool] = None,
+    ) -> Result[bool]:
         """Delete all documents in the collection.
 
+        :param sync: Block until deletion operation is synchronized to disk.
+        :param compact: Whether to compact the collection after truncation.
         :return: True if collection was truncated successfully.
         :rtype: bool
         :raise arango.exceptions.CollectionTruncateError: If operation fails.
         """
+        params: Json = {}
+        if sync is not None:
+            params["waitForSync"] = sync
+        if compact is not None:
+            params["compact"] = compact
+
         request = Request(
-            method="put", endpoint=f"/_api/collection/{self.name}/truncate"
+            method="put",
+            endpoint=f"/_api/collection/{self.name}/truncate",
+            params=params,
         )
 
         def response_handler(resp: Response) -> bool:

--- a/arango/utils.py
+++ b/arango/utils.py
@@ -64,11 +64,11 @@ def get_doc_id(doc: Union[str, Json]) -> str:
 
 
 def is_none_or_int(obj: Any) -> bool:
-    """Check if obj is None or an integer.
+    """Check if obj is None or a positive integer.
 
     :param obj: Object to check.
     :type obj: Any
-    :return: True if object is None or an integer.
+    :return: True if object is None or a positive integer.
     :rtype: bool
     """
     return obj is None or (isinstance(obj, int) and obj >= 0)
@@ -128,11 +128,11 @@ def build_filter_conditions(filters: Json) -> str:
     return "FILTER " + " AND ".join(conditions)
 
 
-def validate_sort_parameters(sort: Sequence[Json]) -> bool:
+def validate_sort_parameters(sort: Jsons) -> bool:
     """Validate sort parameters for an AQL query.
 
     :param sort: Document sort parameters.
-    :type sort: Sequence[Json]
+    :type sort: Jsons
     :return: Validation success.
     :rtype: bool
     :raise arango.exceptions.SortValidationError: If sort parameters are invalid.

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -136,6 +136,8 @@ def test_collection_misc_methods(col, bad_col, cluster):
     # Test truncate collection
     assert col.truncate() is True
     assert len(col) == 0
+    assert col.truncate(sync=True, compact=False) is True
+    assert len(col) == 0
 
     # Test truncate with bad collection
     with assert_raises(CollectionTruncateError) as err:


### PR DESCRIPTION
While I was working on the async driver, I noticed a few things in the collections code:
1. The `truncate` method was missing some parameters: https://github.com/arangodb/python-arango/commit/ca09addfb0a0228c87a37e08e0287b3bc693378c
2. The `overwrite` parameter was unused by `update`: https://github.com/arangodb/python-arango/commit/d5ae65d5c6876a969d9c5813ad3fca26584cc815
3. Some docstrings have been adjusted: https://github.com/arangodb/python-arango/commit/f27348d857899b84dad60d19d520737df505d7e2 and https://github.com/arangodb/python-arango/commit/5bdc7a51c61b368bbc018f9064415469d91704c0 (batch execution is no longer supported)