### PR TITLE
Wait for sync upon graph creation

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -1699,6 +1699,7 @@ class Database(ApiGroup):
         replication_factor: Optional[int] = None,
         write_concern: Optional[int] = None,
         satellite_collections: Optional[Sequence[str]] = None,
+        sync: Optional[bool] = None,
     ) -> Result[Graph]:
         """Create a new graph.
 
@@ -1753,6 +1754,8 @@ class Database(ApiGroup):
             element must be a string and a valid collection name. The
             collection type cannot be modified later.
         :type satellite_collections: [str] | None
+        :param sync: Wait until everything is synced to disk.
+        :type sync: bool | None
         :return: Graph API wrapper.
         :rtype: arango.graph.Graph
         :raise arango.exceptions.GraphCreateError: If create fails.
@@ -1796,7 +1799,16 @@ class Database(ApiGroup):
         if satellite_collections is not None:  # pragma: no cover
             data["options"]["satellites"] = satellite_collections
 
-        request = Request(method="post", endpoint="/_api/gharial", data=data)
+        params: Params = {}
+        if sync is not None:
+            params["waitForSync"] = sync
+
+        request = Request(
+            method="post",
+            endpoint="/_api/gharial",
+            data=data,
+            params=params,
+        )
 
         def response_handler(resp: Response) -> Graph:
             if resp.is_success:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -51,7 +51,7 @@ def test_graph_properties(graph, bad_graph, db):
         bad_graph.properties()
 
     new_graph_name = generate_graph_name()
-    new_graph = db.create_graph(new_graph_name)
+    new_graph = db.create_graph(new_graph_name, sync=True)
     properties = new_graph.properties()
     assert properties["id"] == f"_graphs/{new_graph_name}"
     assert properties["name"] == new_graph_name


### PR DESCRIPTION
This PR comes with two small changes:

1. The [sync parameter](https://docs.arangodb.com/stable/develop/http-api/graphs/named-graphs/#create-a-graph_query_waitForSync) is added to the `create_graph` method.
2. The `has_graph` method is optimized to fetch only the graph properties instead of a list containing all available graphs.