### PR TITLE
API Updates

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -3008,9 +3008,8 @@ class VertexCollection(Collection):
         self,
         vertex: Json,
         sync: Optional[bool] = None,
-        silent: bool = False,
         return_new: bool = False,
-    ) -> Result[Union[bool, Json]]:
+    ) -> Result[Json]:
         """Insert a new vertex document.
 
         :param vertex: New vertex document to insert. If it has "_key" or "_id"
@@ -3019,20 +3018,16 @@ class VertexCollection(Collection):
         :type vertex: dict
         :param sync: Block until operation is synchronized to disk.
         :type sync: bool | None
-        :param silent: If set to True, no document metadata is returned. This
-            can be used to save resources.
-        :type silent: bool
         :param return_new: Include body of the new document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_new: bool
-        :return: Document metadata (e.g. document key, revision), or True if
-            parameter **silent** was set to True.
-        :rtype: bool | dict
+        :return: Document metadata (e.g. document key, revision).
+        :rtype: dict
         :raise arango.exceptions.DocumentInsertError: If insert fails.
         """
         vertex = self._ensure_key_from_id(vertex)
 
-        params: Params = {"silent": silent, "returnNew": return_new}
+        params: Params = {"returnNew": return_new}
         if sync is not None:
             params["waitForSync"] = sync
 
@@ -3044,11 +3039,9 @@ class VertexCollection(Collection):
             write=self.name,
         )
 
-        def response_handler(resp: Response) -> Union[bool, Json]:
+        def response_handler(resp: Response) -> Json:
             if not resp.is_success:
                 raise DocumentInsertError(resp, request)
-            if silent:
-                return True
             return format_vertex(resp.body)
 
         return self._execute(request, response_handler)
@@ -3059,10 +3052,9 @@ class VertexCollection(Collection):
         check_rev: bool = True,
         keep_none: bool = True,
         sync: Optional[bool] = None,
-        silent: bool = False,
         return_old: bool = False,
         return_new: bool = False,
-    ) -> Result[Union[bool, Json]]:
+    ) -> Result[Json]:
         """Update a vertex document.
 
         :param vertex: Partial or full vertex document with updated values. It
@@ -3076,18 +3068,14 @@ class VertexCollection(Collection):
         :type keep_none: bool | None
         :param sync: Block until operation is synchronized to disk.
         :type sync: bool | None
-        :param silent: If set to True, no document metadata is returned. This
-            can be used to save resources.
-        :type silent: bool
         :param return_old: Include body of the old document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_old: bool
         :param return_new: Include body of the new document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_new: bool
-        :return: Document metadata (e.g. document key, revision) or True if
-            parameter **silent** was set to True.
-        :rtype: bool | dict
+        :return: Document metadata (e.g. document key, revision).
+        :rtype: dict
         :raise arango.exceptions.DocumentUpdateError: If update fails.
         :raise arango.exceptions.DocumentRevisionError: If revisions mismatch.
         """
@@ -3096,7 +3084,6 @@ class VertexCollection(Collection):
         params: Params = {
             "keepNull": keep_none,
             "overwrite": not check_rev,
-            "silent": silent,
             "returnNew": return_new,
             "returnOld": return_old,
         }
@@ -3112,13 +3099,11 @@ class VertexCollection(Collection):
             write=self.name,
         )
 
-        def response_handler(resp: Response) -> Union[bool, Json]:
+        def response_handler(resp: Response) -> Json:
             if resp.status_code == 412:  # pragma: no cover
                 raise DocumentRevisionError(resp, request)
             elif not resp.is_success:
                 raise DocumentUpdateError(resp, request)
-            if silent is True:
-                return True
             return format_vertex(resp.body)
 
         return self._execute(request, response_handler)
@@ -3128,10 +3113,9 @@ class VertexCollection(Collection):
         vertex: Json,
         check_rev: bool = True,
         sync: Optional[bool] = None,
-        silent: bool = False,
         return_old: bool = False,
         return_new: bool = False,
-    ) -> Result[Union[bool, Json]]:
+    ) -> Result[Json]:
         """Replace a vertex document.
 
         :param vertex: New vertex document to replace the old one with. It must
@@ -3142,25 +3126,20 @@ class VertexCollection(Collection):
         :type check_rev: bool
         :param sync: Block until operation is synchronized to disk.
         :type sync: bool | None
-        :param silent: If set to True, no document metadata is returned. This
-            can be used to save resources.
-        :type silent: bool
         :param return_old: Include body of the old document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_old: bool
         :param return_new: Include body of the new document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_new: bool
-        :return: Document metadata (e.g. document key, revision) or True if
-            parameter **silent** was set to True.
-        :rtype: bool | dict
+        :return: Document metadata (e.g. document key, revision).
+        :rtype: dict
         :raise arango.exceptions.DocumentReplaceError: If replace fails.
         :raise arango.exceptions.DocumentRevisionError: If revisions mismatch.
         """
         vertex_id, headers = self._prep_from_body(vertex, check_rev)
 
         params: Params = {
-            "silent": silent,
             "returnNew": return_new,
             "returnOld": return_old,
         }
@@ -3176,13 +3155,11 @@ class VertexCollection(Collection):
             write=self.name,
         )
 
-        def response_handler(resp: Response) -> Union[bool, Json]:
+        def response_handler(resp: Response) -> Json:
             if resp.status_code == 412:  # pragma: no cover
                 raise DocumentRevisionError(resp, request)
             elif not resp.is_success:
                 raise DocumentReplaceError(resp, request)
-            if silent is True:
-                return True
             return format_vertex(resp.body)
 
         return self._execute(request, response_handler)
@@ -3326,9 +3303,8 @@ class EdgeCollection(Collection):
         self,
         edge: Json,
         sync: Optional[bool] = None,
-        silent: bool = False,
         return_new: bool = False,
-    ) -> Result[Union[bool, Json]]:
+    ) -> Result[Json]:
         """Insert a new edge document.
 
         :param edge: New edge document to insert. It must contain "_from" and
@@ -3338,20 +3314,16 @@ class EdgeCollection(Collection):
         :type edge: dict
         :param sync: Block until operation is synchronized to disk.
         :type sync: bool | None
-        :param silent: If set to True, no document metadata is returned. This
-            can be used to save resources.
-        :type silent: bool
         :param return_new: Include body of the new document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_new: bool
-        :return: Document metadata (e.g. document key, revision) or True if
-            parameter **silent** was set to True.
-        :rtype: bool | dict
+        :return: Document metadata (e.g. document key, revision).
+        :rtype: dict
         :raise arango.exceptions.DocumentInsertError: If insert fails.
         """
         edge = self._ensure_key_from_id(edge)
 
-        params: Params = {"silent": silent, "returnNew": return_new}
+        params: Params = {"returnNew": return_new}
         if sync is not None:
             params["waitForSync"] = sync
 
@@ -3363,11 +3335,9 @@ class EdgeCollection(Collection):
             write=self.name,
         )
 
-        def response_handler(resp: Response) -> Union[bool, Json]:
+        def response_handler(resp: Response) -> Json:
             if not resp.is_success:
                 raise DocumentInsertError(resp, request)
-            if silent:
-                return True
             return format_edge(resp.body)
 
         return self._execute(request, response_handler)
@@ -3378,10 +3348,9 @@ class EdgeCollection(Collection):
         check_rev: bool = True,
         keep_none: bool = True,
         sync: Optional[bool] = None,
-        silent: bool = False,
         return_old: bool = False,
         return_new: bool = False,
-    ) -> Result[Union[bool, Json]]:
+    ) -> Result[Json]:
         """Update an edge document.
 
         :param edge: Partial or full edge document with updated values. It must
@@ -3395,18 +3364,14 @@ class EdgeCollection(Collection):
         :type keep_none: bool | None
         :param sync: Block until operation is synchronized to disk.
         :type sync: bool | None
-        :param silent: If set to True, no document metadata is returned. This
-            can be used to save resources.
-        :type silent: bool
         :param return_old: Include body of the old document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_old: bool
         :param return_new: Include body of the new document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_new: bool
-        :return: Document metadata (e.g. document key, revision) or True if
-            parameter **silent** was set to True.
-        :rtype: bool | dict
+        :return: Document metadata (e.g. document key, revision).
+        :rtype: dict
         :raise arango.exceptions.DocumentUpdateError: If update fails.
         :raise arango.exceptions.DocumentRevisionError: If revisions mismatch.
         """
@@ -3415,7 +3380,6 @@ class EdgeCollection(Collection):
         params: Params = {
             "keepNull": keep_none,
             "overwrite": not check_rev,
-            "silent": silent,
             "returnNew": return_new,
             "returnOld": return_old,
         }
@@ -3431,13 +3395,11 @@ class EdgeCollection(Collection):
             write=self.name,
         )
 
-        def response_handler(resp: Response) -> Union[bool, Json]:
+        def response_handler(resp: Response) -> Json:
             if resp.status_code == 412:  # pragma: no cover
                 raise DocumentRevisionError(resp, request)
             if not resp.is_success:
                 raise DocumentUpdateError(resp, request)
-            if silent is True:
-                return True
             return format_edge(resp.body)
 
         return self._execute(request, response_handler)
@@ -3447,10 +3409,9 @@ class EdgeCollection(Collection):
         edge: Json,
         check_rev: bool = True,
         sync: Optional[bool] = None,
-        silent: bool = False,
         return_old: bool = False,
         return_new: bool = False,
-    ) -> Result[Union[bool, Json]]:
+    ) -> Result[Json]:
         """Replace an edge document.
 
         :param edge: New edge document to replace the old one with. It must
@@ -3462,25 +3423,20 @@ class EdgeCollection(Collection):
         :type check_rev: bool
         :param sync: Block until operation is synchronized to disk.
         :type sync: bool | None
-        :param silent: If set to True, no document metadata is returned. This
-            can be used to save resources.
-        :type silent: bool
         :param return_old: Include body of the old document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_old: bool
         :param return_new: Include body of the new document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_new: bool
-        :return: Document metadata (e.g. document key, revision) or True if
-            parameter **silent** was set to True.
-        :rtype: bool | dict
+        :return: Document metadata (e.g. document key, revision).
+        :rtype: dict
         :raise arango.exceptions.DocumentReplaceError: If replace fails.
         :raise arango.exceptions.DocumentRevisionError: If revisions mismatch.
         """
         edge_id, headers = self._prep_from_body(edge, check_rev)
 
         params: Params = {
-            "silent": silent,
             "returnNew": return_new,
             "returnOld": return_old,
         }
@@ -3496,13 +3452,11 @@ class EdgeCollection(Collection):
             write=self.name,
         )
 
-        def response_handler(resp: Response) -> Union[bool, Json]:
+        def response_handler(resp: Response) -> Json:
             if resp.status_code == 412:  # pragma: no cover
                 raise DocumentRevisionError(resp, request)
             if not resp.is_success:
                 raise DocumentReplaceError(resp, request)
-            if silent is True:
-                return True
             return format_edge(resp.body)
 
         return self._execute(request, response_handler)
@@ -3575,9 +3529,8 @@ class EdgeCollection(Collection):
         to_vertex: Union[str, Json],
         data: Optional[Json] = None,
         sync: Optional[bool] = None,
-        silent: bool = False,
         return_new: bool = False,
-    ) -> Result[Union[bool, Json]]:
+    ) -> Result[Json]:
         """Insert a new edge document linking the given vertices.
 
         :param from_vertex: "From" vertex document ID or body with "_id" field.
@@ -3590,21 +3543,17 @@ class EdgeCollection(Collection):
         :type data: dict | None
         :param sync: Block until operation is synchronized to disk.
         :type sync: bool | None
-        :param silent: If set to True, no document metadata is returned. This
-            can be used to save resources.
-        :type silent: bool
         :param return_new: Include body of the new document in the returned
             metadata. Ignored if parameter **silent** is set to True.
         :type return_new: bool
-        :return: Document metadata (e.g. document key, revision) or True if
-            parameter **silent** was set to True.
-        :rtype: bool | dict
+        :return: Document metadata (e.g. document key, revision).
+        :rtype: dict
         :raise arango.exceptions.DocumentInsertError: If insert fails.
         """
         edge = {"_from": get_doc_id(from_vertex), "_to": get_doc_id(to_vertex)}
         if data is not None:
             edge.update(self._ensure_key_from_id(data))
-        return self.insert(edge, sync=sync, silent=silent, return_new=return_new)
+        return self.insert(edge, sync=sync, return_new=return_new)
 
     def edges(
         self,

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -543,6 +543,10 @@ class VertexCollectionDeleteError(ArangoServerError):
     """Failed to delete vertex collection."""
 
 
+class EdgeCollectionListError(ArangoServerError):
+    """Failed to retrieve edge collections."""
+
+
 class EdgeDefinitionListError(ArangoServerError):
     """Failed to retrieve edge definitions."""
 

--- a/arango/request.py
+++ b/arango/request.py
@@ -12,7 +12,7 @@ def normalize_headers(
     if driver_flags is not None:
         for flag in driver_flags:
             flags = flags + flag + ";"
-    driver_version = "8.1.7"
+    driver_version = "8.2.0"
     driver_header = "python-arango/" + driver_version + " (" + flags + ")"
     normalized_headers: Headers = {
         "charset": "utf-8",

--- a/docs/graph.rst
+++ b/docs/graph.rst
@@ -83,6 +83,7 @@ Here is an example showing how edge definitions are managed:
 
     # Create an edge definition named "teach". This creates any missing
     # collections and returns an API wrapper for "teach" edge collection.
+    # At first, create a wrong teachers->teachers mapping intentionally.
     if not school.has_edge_definition('teach'):
         teach = school.create_edge_definition(
             edge_collection='teach',
@@ -93,7 +94,7 @@ Here is an example showing how edge definitions are managed:
     # List edge definitions.
     school.edge_definitions()
 
-    # Replace the edge definition.
+    # Replace with the correct edge definition.
     school.replace_edge_definition(
         edge_collection='teach',
         from_vertex_collections=['teachers'],

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -334,6 +334,7 @@ def test_create_graph_with_edge_definition(db):
     )
     assert edge_definition in new_graph.edge_definitions()
     assert ovcol_name in new_graph.vertex_collections()
+    assert edge_definition["edge_collection"] in new_graph.edge_collections()
 
 
 def test_vertex_management(fvcol, bad_fvcol, fvdocs):
@@ -394,7 +395,7 @@ def test_vertex_management(fvcol, bad_fvcol, fvdocs):
     key = vertex["_key"]
 
     # Test insert third valid vertex with silent set to True
-    assert fvcol.insert(vertex, silent=True) is True
+    assert isinstance(fvcol.insert(vertex), dict)
     assert len(fvcol) == 3
     assert fvcol[key]["val"] == vertex["val"]
 
@@ -444,7 +445,7 @@ def test_vertex_management(fvcol, bad_fvcol, fvdocs):
 
     # Test update vertex with silent set to True
     assert "bar" not in fvcol[vertex]
-    assert fvcol.update({"_key": key, "bar": 200}, silent=True) is True
+    assert isinstance(fvcol.update({"_key": key, "bar": 200}), dict)
     assert fvcol[vertex]["bar"] == 200
     assert fvcol[vertex]["_rev"] != old_rev
     old_rev = fvcol[key]["_rev"]
@@ -519,7 +520,7 @@ def test_vertex_management(fvcol, bad_fvcol, fvdocs):
     assert "vertex" in result
 
     # Test replace vertex with silent set to True
-    assert fvcol.replace({"_key": key, "bar": 200}, silent=True) is True
+    assert isinstance(fvcol.replace({"_key": key, "bar": 200}), dict)
     assert "foo" not in fvcol[key]
     assert "baz" not in fvcol[vertex]
     assert fvcol[vertex]["bar"] == 200
@@ -698,7 +699,7 @@ def test_edge_management(ecol, bad_ecol, edocs, fvcol, fvdocs, tvcol, tvdocs):
     key = edge["_key"]
 
     # Test insert second valid edge with silent set to True
-    assert ecol.insert(edge, sync=True, silent=True) is True
+    assert isinstance(ecol.insert(edge, sync=True), dict)
     assert edge in ecol and key in ecol
     assert len(ecol) == 2
     assert ecol[key]["_from"] == edge["_from"]
@@ -714,15 +715,14 @@ def test_edge_management(ecol, bad_ecol, edocs, fvcol, fvdocs, tvcol, tvdocs):
     # Test insert fourth valid edge using link method
     from_vertex = fvcol.get(fvdocs[2])
     to_vertex = tvcol.get(tvdocs[0])
-    assert (
+    assert isinstance(
         ecol.link(
             from_vertex["_id"],
             to_vertex["_id"],
             {"_id": ecol.name + "/foo"},
             sync=True,
-            silent=True,
-        )
-        is True
+        ),
+        dict,
     )
     assert "foo" in ecol
     assert len(ecol) == 4
@@ -816,7 +816,7 @@ def test_edge_management(ecol, bad_ecol, edocs, fvcol, fvdocs, tvcol, tvdocs):
     old_rev = result["_rev"]
 
     # Test update edge with silent option
-    assert ecol.update({"_key": key, "bar": 600}, silent=True) is True
+    assert isinstance(ecol.update({"_key": key, "bar": 600}), dict)
     assert ecol[key]["foo"] == 200
     assert ecol[key]["bar"] == 600
     assert ecol[key]["_rev"] != old_rev
@@ -852,7 +852,7 @@ def test_edge_management(ecol, bad_ecol, edocs, fvcol, fvdocs, tvcol, tvdocs):
 
     # Test replace edge with silent set to True
     edge["bar"] = 200
-    assert ecol.replace(edge, silent=True) is True
+    assert isinstance(ecol.replace(edge), dict)
     assert ecol[key]["foo"] == 100
     assert ecol[key]["bar"] == 200
     assert ecol[key]["_rev"] != old_rev


### PR DESCRIPTION
This PR does not modify much of the implementation, but adds or removes parameters to some of the graph-related functions.

- Vertex and Edge collections don't (actually never did) support the `silent` parameter. This could be confusing and it just makes type hinting more awkward because we have to return an `Union` instead of the actual type. See https://docs.arangodb.com/stable/develop/http-api/graphs/named-graphs/.
- Creating a vertex or edge collection has an additional `options` parameter which was not available in the driver.
- `replace_edge_definition` and `replace_vertex` were missing the `sync` parameter.
- The `edge_collections` method was missing. It corresponds to https://docs.arangodb.com/stable/develop/http-api/graphs/named-graphs/#list-edge-collections
- Added comments in `graph.rst` in order to clear up confusion about our "Edge definitions" example (see https://github.com/arangodb/python-arango/pull/371)

Changed the driver version, so we can do a new release.
