### PR TITLE
Skip _db prefix on /_open/auth

### DIFF
--- a/starter.sh
+++ b/starter.sh
@@ -6,7 +6,7 @@
 # Usage:
 #   ./starter.sh [single|cluster] [community|enterprise] [version]
 # Example:
-#   ./starter.sh cluster enterprise 3.12.1
+#   ./starter.sh cluster enterprise 3.12.5
 
 setup="${1:-single}"
 license="${2:-community}"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -439,18 +439,23 @@ def test_database_utf8(sys_db, special_db_names):
         assert sys_db.delete_database(name)
 
 
-def test_license(sys_db, enterprise):
+def test_license(sys_db, enterprise, db_version):
     license = sys_db.license()
     assert isinstance(license, dict)
 
-    if enterprise:
-        assert set(license.keys()) == {
+    if db_version >= version.parse("3.12.5"):
+        expected_keys = {"diskUsage", "upgrading"}
+    else:
+        expected_keys = {
             "upgrading",
             "features",
             "license",
             "version",
             "status",
         }
+
+    if enterprise:
+        assert set(license.keys()) == expected_keys
     else:
         assert license == {"license": "none"}
         with pytest.raises(ServerLicenseSetError):


### PR DESCRIPTION
Using `_db/{db_name}/_open/auth` is obsolete. We should simply use `/_open/auth` instead.