### PR TITLE
Adding support for /key-generators

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -27,6 +27,7 @@ from arango.exceptions import (
     AsyncJobListError,
     CollectionCreateError,
     CollectionDeleteError,
+    CollectionKeyGeneratorsError,
     CollectionListError,
     DatabaseCompactError,
     DatabaseCreateError,
@@ -1620,6 +1621,23 @@ class Database(ApiGroup):
             if not resp.is_success:
                 raise CollectionDeleteError(resp, request)
             return True
+
+        return self._execute(request, response_handler)
+
+    def key_generators(self) -> Result[List[str]]:
+        """Returns the available key generators for collections.
+
+        :return: List of available key generators.
+        :rtype: [str]
+        :raise arango.exceptions.CollectionKeyGeneratorsError: If retrieval fails.
+        """  # noqa: E501
+        request = Request(method="get", endpoint="/_api/key-generators")
+
+        def response_handler(resp: Response) -> List[str]:
+            if not resp.is_success:
+                raise CollectionKeyGeneratorsError(resp, request)
+            result: List[str] = resp.body["keyGenerators"]
+            return result
 
         return self._execute(request, response_handler)
 

--- a/arango/exceptions.py
+++ b/arango/exceptions.py
@@ -298,6 +298,10 @@ class CollectionTruncateError(ArangoServerError):
     """Failed to truncate collection."""
 
 
+class CollectionKeyGeneratorsError(ArangoServerError):
+    """Failed to retrieve key generators."""
+
+
 class CollectionLoadError(ArangoServerError):
     """Failed to load collection."""
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -13,6 +13,7 @@ from arango.errno import (
     USE_SYSTEM_DATABASE,
 )
 from arango.exceptions import (
+    CollectionKeyGeneratorsError,
     DatabaseCompactError,
     DatabaseCreateError,
     DatabaseDeleteError,
@@ -347,6 +348,12 @@ def test_database_misc_methods(client, sys_db, db, bad_db, cluster, secret, db_v
     db_superuser = client.db(db.name, superuser_token=token)
     result = db_superuser.compact()
     assert result == {}
+
+    if db_version >= version.parse("3.12.0"):
+        key_generators = db.key_generators()
+        assert isinstance(key_generators, list)
+        with pytest.raises(CollectionKeyGeneratorsError):
+            bad_db.key_generators()
 
 
 def test_database_management(db, sys_db, bad_db):


### PR DESCRIPTION
Add support for `GET /_db/{database-name}/_api/key-generators` introduced in 3.12

See https://docs.arangodb.com/stable/develop/http-api/collections/#get-the-available-key-generators