### PR TITLE
Deprecate load/unload methods

### DIFF
--- a/arango/backup.py
+++ b/arango/backup.py
@@ -33,7 +33,7 @@ class Backup(ApiGroup):  # pragma: no cover
         :type backup_id: str
         :return: Backup details.
         :rtype: dict
-        :raise arango.exceptions.BackupGetError: If delete fails.
+        :raise arango.exceptions.BackupGetError: If the operation fails.
         """
         request = Request(
             method="post",

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -537,10 +537,19 @@ class Collection(ApiGroup):
     def load(self) -> Result[bool]:
         """Load the collection into memory.
 
+        .. note::
+            The load function is deprecated from version 3.8.0 onwards and is a
+            no-op from version 3.9.0 onwards. It should no longer be used, as it
+            may be removed in a future version of ArangoDB.
+
         :return: True if collection was loaded successfully.
         :rtype: bool
         :raise arango.exceptions.CollectionLoadError: If operation fails.
         """
+
+        m = "The load function is deprecated from version 3.8.0 onwards and is a no-op from version 3.9.0 onwards."  # noqa: E501
+        warn(m, DeprecationWarning, stacklevel=2)
+
         request = Request(method="put", endpoint=f"/_api/collection/{self.name}/load")
 
         def response_handler(resp: Response) -> bool:

--- a/arango/collection.py
+++ b/arango/collection.py
@@ -546,7 +546,6 @@ class Collection(ApiGroup):
         :rtype: bool
         :raise arango.exceptions.CollectionLoadError: If operation fails.
         """
-
         m = "The load function is deprecated from version 3.8.0 onwards and is a no-op from version 3.9.0 onwards."  # noqa: E501
         warn(m, DeprecationWarning, stacklevel=2)
 
@@ -562,10 +561,18 @@ class Collection(ApiGroup):
     def unload(self) -> Result[bool]:
         """Unload the collection from memory.
 
+        .. note::
+            The unload function is deprecated from version 3.8.0 onwards and is a
+            no-op from version 3.9.0 onwards. It should no longer be used, as it
+            may be removed in a future version of ArangoDB.
+
         :return: True if collection was unloaded successfully.
         :rtype: bool
         :raise arango.exceptions.CollectionUnloadError: If operation fails.
         """
+        m = "The unload function is deprecated from version 3.8.0 onwards and is a no-op from version 3.9.0 onwards."  # noqa: E501
+        warn(m, DeprecationWarning, stacklevel=2)
+
         request = Request(method="put", endpoint=f"/_api/collection/{self.name}/unload")
 
         def response_handler(resp: Response) -> bool:


### PR DESCRIPTION
The collection load and unload methods have long been deprecate and are just NOPs since 3.9.

We should at least let the users know that these methods have no effect, and can safely be removed from their codebase.

See
- https://docs.arangodb.com/stable/develop/http-api/collections/#load-a-collection
- https://docs.arangodb.com/stable/develop/http-api/collections/#unload-a-collection