### PR TITLE
Updating test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ workflows:
           name:  Python (<< matrix.python_version >>) - ArangoDB (<< matrix.arangodb_license >>, << matrix.arangodb_version >> << matrix.arangodb_config >>)
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12"]
+              python_version: ["3.10", "3.11", "3.12"]
               arangodb_config: ["single", "cluster"]
-              arangodb_license: ["community", "enterprise"]
-              arangodb_version: ["3.11", "latest"]
+              arangodb_license: ["enterprise"]
+              arangodb_version: ["latest"]
 
 jobs:
   lint:


### PR DESCRIPTION
1. Python 3.9 is no longer supported
2. Community is basically enterprise

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CircleCI test matrix by dropping Python 3.9 and limiting ArangoDB to enterprise license on latest version.
> 
> - **CI (CircleCI `/.circleci/config.yml`)**:
>   - **Test Matrix**:
>     - Drop Python `3.9`; test on `3.10`, `3.11`, `3.12`.
>     - Restrict ArangoDB to `enterprise` license only.
>     - Pin ArangoDB version to `latest` (remove `3.11`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba4888cfcaa87b5d8da051f631a1af68ca2c6408. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->