### PR TITLE
Database "path" property is no longer available in 4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   python-container:
     docker:
       - image: cimg/python:3.12
-    resource_class: small
+    resource_class: arangodb/small-amd64
   python-vm:
     machine:
       image: ubuntu-2404:current
@@ -26,7 +26,7 @@ workflows:
 jobs:
   lint:
     executor: python-container
-    resource_class: small
+    resource_class: arangodb/small-amd64
     steps:
       - checkout
       - run:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -73,7 +73,10 @@ def test_database_misc_methods(client, sys_db, db, bad_db, cluster, secret, db_v
     # Test get properties
     properties = db.properties()
     assert "id" in properties
-    assert "path" in properties
+
+    if db_version < version.parse("4.0"):
+        assert "path" in properties
+
     assert properties["name"] == db.name
     assert properties["system"] is False
 


### PR DESCRIPTION
The workaround is to check the database version before verifying this property.