### PR TITLE
Added 4.0 nightly to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
               args+=("--cluster" "--port=8539" "--port=8549")
             fi
 
-            if [ << parameters.arangodb_license >> != "enterprise" ]; then
+            if [ << parameters.arangodb_license >> != "enterprise" ] && [ << parameters.arangodb_license >> != "enterprise-preview" ]; then
               args+=("--skip" "enterprise")
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,16 +50,16 @@ jobs:
           command: pip install .[dev]
       - run:
             name: Run black
-            command: black --check --verbose --diff --color --config=pyproject.toml ./arangoasync ./tests/
+            command: black --check --verbose --diff --color --config=pyproject.toml ./arango ./tests/
       - run:
           name: Run flake8
-          command: flake8 ./arangoasync ./tests
+          command: flake8 ./arango ./tests
       - run:
           name: Run isort
-          command: isort --check ./arangoasync ./tests
+          command: isort --check ./arango ./tests
       - run:
           name: Run mypy
-          command: mypy ./arangoasync
+          command: mypy ./arango
   test:
     parameters:
         python_version:
@@ -107,7 +107,7 @@ jobs:
             fi
 
             echo "Running pytest with args: ${args[@]}"
-            pytest --cov=arangoasync --cov-report=html:htmlcov --color=yes --code-highlight=yes "${args[@]}"
+            pytest --cov=arango --cov-report=html:htmlcov --color=yes --code-highlight=yes "${args[@]}"
       - store_artifacts:
           path: htmlcov
           destination: coverage-report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,27 @@ workflows:
     jobs:
       - lint
       - test:
-          name:  Python (<< matrix.python_version >>) - ArangoDB (<< matrix.arangodb_license >>, << matrix.arangodb_version >> << matrix.arangodb_config >>)
+          name: Python (<< matrix.python_version >>) - ArangoDB (enterprise, << matrix.arangodb_version >> << matrix.arangodb_config >>)
+          matrix:
+            parameters:
+              python_version: ["3.13"]
+              arangodb_config: ["single", "cluster"]
+              arangodb_license: ["enterprise"]
+              arangodb_version: ["3.12"]
+      - test:
+          name: Python (<< matrix.python_version >>) - ArangoDB (enterprise-preview, << matrix.arangodb_version >> << matrix.arangodb_config >>)
+          matrix:
+            parameters:
+              python_version: ["3.13"]
+              arangodb_config: ["single", "cluster"]
+              arangodb_license: ["enterprise-preview"]
+              arangodb_version: ["4.0-nightly"]
+      - test:
+          name: Python (<< matrix.python_version >>) - ArangoDB (enterprise, 3.12 cluster)
           matrix:
             parameters:
               python_version: ["3.10", "3.11", "3.12"]
-              arangodb_config: ["single", "cluster"]
+              arangodb_config: ["cluster"]
               arangodb_license: ["enterprise"]
               arangodb_version: ["3.12"]
 
@@ -34,16 +50,16 @@ jobs:
           command: pip install .[dev]
       - run:
             name: Run black
-            command: black --check --verbose --diff --color --config=pyproject.toml ./arango ./tests/
+            command: black --check --verbose --diff --color --config=pyproject.toml ./arangoasync ./tests/
       - run:
           name: Run flake8
-          command: flake8 ./arango ./tests
+          command: flake8 ./arangoasync ./tests
       - run:
           name: Run isort
-          command: isort --check ./arango ./tests
+          command: isort --check ./arangoasync ./tests
       - run:
           name: Run mypy
-          command: mypy ./arango
+          command: mypy ./arangoasync
   test:
     parameters:
         python_version:
@@ -91,7 +107,7 @@ jobs:
             fi
 
             echo "Running pytest with args: ${args[@]}"
-            pytest --cov=arango --cov-report=html:htmlcov --color=yes --code-highlight=yes "${args[@]}"
+            pytest --cov=arangoasync --cov-report=html:htmlcov --color=yes --code-highlight=yes "${args[@]}"
       - store_artifacts:
           path: htmlcov
           destination: coverage-report

--- a/starter.sh
+++ b/starter.sh
@@ -4,12 +4,15 @@
 # Useful for testing the python-arango driver against a local ArangoDB setup.
 
 # Usage:
-#   ./starter.sh [single|cluster] [community|enterprise] [version]
+#   ./starter.sh [single|cluster] [community|enterprise|enterprise-preview] [version]
+#   ./starter.sh [single|cluster] [image[:tag]]
 # Example:
-#   ./starter.sh cluster enterprise 3.12.5
+#   ./starter.sh cluster enterprise 3.12.4
+#   ./starter.sh single enterprise-preview 4.0-nightly
+#   ./starter.sh single arangodb/enterprise-preview:4.0-nightly
 
-setup="${1:-cluster}"
-license="${2:-enterprise}"
+setup="${1:-single}"
+image="${2:-community}"
 version="${3:-latest}"
 
 extra_ports=""
@@ -22,22 +25,38 @@ else
     exit 1
 fi
 
-image_name=""
-if [ "$license" == "community" ]; then
-    image_name="arangodb"
-elif [ "$license" == "enterprise" ]; then
-    image_name="enterprise"
+image_ref=""
+if [[ "$image" == */* ]]; then
+    if [[ "$image" == *:* ]]; then
+        image_ref="$image"
+        if [ "$version" == "latest" ]; then
+            version="${image##*:}"
+        fi
+    else
+        image_ref="$image:$version"
+    fi
+elif [ "$image" == "community" ]; then
+    image_ref="arangodb/arangodb:$version"
+elif [ "$image" == "enterprise" ]; then
+    image_ref="arangodb/enterprise:$version"
+elif [ "$image" == "enterprise-preview" ]; then
+    image_ref="arangodb/enterprise-preview:$version"
 else
-    echo "Invalid argument. Please provide either 'community' or 'enterprise'."
+    echo "Invalid argument. Please provide 'community', 'enterprise', 'enterprise-preview', or a full image reference."
     exit 1
 fi
 
 if [ "$version" == "latest" ]; then
     conf_file="${setup}-3.12"
-elif [[ "$version" == *.*.* ]]; then
-    conf_file="${setup}-${version%.*}"
+elif [[ "$version" =~ ^([0-9]+\.[0-9]+) ]]; then
+    conf_file="${setup}-${BASH_REMATCH[1]}"
 else
     conf_file="${setup}-${version}"
+fi
+
+if [ ! -f "tests/static/$conf_file.conf" ]; then
+    echo "Missing configuration file: tests/static/$conf_file.conf"
+    exit 1
 fi
 
 docker run -d \
@@ -47,8 +66,13 @@ docker run -d \
   $extra_ports \
   -v "$(pwd)/tests/static/":/tests/static \
   -v /tmp:/tmp \
-  "arangodb/$image_name:$version" \
+  "$image_ref" \
   /bin/sh -c "arangodb --configuration=/tests/static/$conf_file.conf"
+
+if [ $? -ne 0 ]; then
+    echo "ERROR starter failed to start container"
+    exit 1
+fi
 
 wget --quiet --waitretry=1 --tries=120 -O - http://localhost:8528/version | jq
 if [ $? -eq 0 ]; then

--- a/tests/static/cluster-4.0.conf
+++ b/tests/static/cluster-4.0.conf
@@ -1,0 +1,15 @@
+[starter]
+mode = cluster
+local = true
+address = 0.0.0.0
+port = 8528
+
+[auth]
+jwt-secret = /tests/static/keyfile
+
+[args]
+all.database.password = passwd
+all.vector-index = true
+all.database.extended-names = true
+all.log.api-enabled = true
+all.server.options-api = admin

--- a/tests/static/single-4.0.conf
+++ b/tests/static/single-4.0.conf
@@ -1,0 +1,14 @@
+[starter]
+mode = single
+address = 0.0.0.0
+port = 8528
+
+[auth]
+jwt-secret = /tests/static/keyfile
+
+[args]
+all.database.password = passwd
+all.vector-index = true
+all.database.extended-names = true
+all.log.api-enabled = true
+all.server.options-api = admin

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -13,9 +13,12 @@ from arango.exceptions import (
 from tests.helpers import extract, generate_db_name
 
 
-def test_transaction_execute_raw(db, col, docs, skip_tests):
+def test_transaction_execute_raw(db, col, docs, skip_tests, db_version):
     if "js-transactions" in skip_tests:
         pytest.skip("Skipping JS transaction tests")
+
+    if db_version >= version.parse("4.0"):
+        pytest.skip("Javascript transactions are no longer supported in ArangoDB 4.0")
 
     # Test execute raw transaction
     doc = docs[0]


### PR DESCRIPTION
Enable testing against arangodb/enterprise-preview:4.0-nightly by adding 4.0 starter configs and CI matrix coverage.