### PR TITLE
Removing deprecated replication APIs.

### DIFF
--- a/arango/replication.py
+++ b/arango/replication.py
@@ -208,7 +208,9 @@ class Replication(ApiGroup):
         restrict_collections: Optional[Sequence[str]] = None,
         initial_sync_wait_time: Optional[int] = None,
     ) -> Result[Json]:  # pragma: no cover
-        """Synchronize data from a remote endpoint.
+        """**Removed** in ArangoDB v3.12.10.
+
+        Synchronize data from a remote endpoint.
 
         :param endpoint: Master endpoint (e.g. "tcp://192.168.173.13:8529").
         :type endpoint: str
@@ -246,6 +248,9 @@ class Replication(ApiGroup):
         :rtype: dict
         :raise arango.exceptions.ReplicationSyncError: If sync fails.
         """
+        m = "/_api/replication/sync was removed in ArangoDB v3.12.10."
+        warn(m, DeprecationWarning, stacklevel=2)
+
         data: Json = {"endpoint": endpoint}
 
         if database is not None:
@@ -319,13 +324,18 @@ class Replication(ApiGroup):
         return self._execute(request, response_handler)
 
     def logger_first_tick(self) -> Result[str]:
-        """Return the first available tick value from the server.
+        """**Removed** in ArangoDB v3.12.10.
+
+        Return the first available tick value from the server.
 
         :return: First tick value.
         :rtype: str
         :raise arango.exceptions.ReplicationLoggerFirstTickError: If retrieval fails.
         """
-        m = "/_api/replication/logger-first-tick endpoint is removed in ArangoDB v4.0"
+        m = (
+            "/_api/replication/logger-first-tick endpoint is removed in "
+            "ArangoDB v3.12.10."
+        )
         warn(m, DeprecationWarning, stacklevel=2)
 
         request = Request(
@@ -618,12 +628,17 @@ class Replication(ApiGroup):
         return self._execute(request, response_handler)
 
     def server_id(self) -> Result[str]:
-        """Return this server's ID.
+        """**Removed** in ArangoDB v3.12.10.
+
+        Return this server's ID.
 
         :return: Server ID.
         :rtype: str
         :raise arango.exceptions.ReplicationServerIDError: If retrieval fails.
         """
+        m = "/_api/replication/server-id was removed in ArangoDB v3.12.10."
+        warn(m, DeprecationWarning, stacklevel=2)
+
         request = Request(
             method="get",
             endpoint="/_api/replication/server-id",

--- a/docs/replication.rst
+++ b/docs/replication.rst
@@ -57,22 +57,5 @@ information, refer to `ArangoDB manual`_.
     # Get the logger state.
     replication.logger_state()
 
-    # Get the logger first tick value.
-    replication.logger_first_tick()
-
-    # Get the server ID.
-    replication.server_id()
-
-    # Synchronize data from a remote (master) endpoint
-    replication.synchronize(
-        endpoint='tcp://master:8500',
-        database='test',
-        username='root',
-        password='passwd',
-        include_system=False,
-        incremental=False,
-        restrict_type='include',
-        restrict_collections=['students']
-    )
 
 See :ref:`Replication` for API specification.

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -15,8 +15,6 @@ from arango.exceptions import (
     ReplicationDumpError,
     ReplicationInventoryError,
     ReplicationLoggerStateError,
-    ReplicationServerIDError,
-    ReplicationSyncError,
 )
 from tests.helpers import assert_raises
 
@@ -106,36 +104,4 @@ def test_replication_cluster_inventory(sys_db, bad_db, cluster):
 
     with assert_raises(ReplicationClusterInventoryError) as err:
         bad_db.replication.cluster_inventory(include_system=True)
-    assert err.value.error_code in {FORBIDDEN, DATABASE_NOT_FOUND}
-
-
-def test_replication_server_id(sys_db, bad_db):
-    result = sys_db.replication.server_id()
-    assert isinstance(result, str)
-
-    with assert_raises(ReplicationServerIDError) as err:
-        bad_db.replication.server_id()
-    assert err.value.error_code in {FORBIDDEN, DATABASE_NOT_FOUND}
-
-
-def test_replication_synchronize(sys_db, bad_db, url, replication):
-    if not replication:
-        pytest.skip("Only tested for replication")
-
-    result = sys_db.replication.synchronize(
-        endpoint="tcp://192.168.1.65:8500",
-        database="test",
-        username="root",
-        password="passwd",
-        include_system=False,
-        incremental=False,
-        restrict_type="include",
-        restrict_collections=["test"],
-        initial_sync_wait_time=None,
-    )
-    assert "collections" in result
-    assert "last_log_tick" in result
-
-    with assert_raises(ReplicationSyncError) as err:
-        bad_db.replication.synchronize(endpoint=url)
     assert err.value.error_code in {FORBIDDEN, DATABASE_NOT_FOUND}


### PR DESCRIPTION
- /_api/replication/sync
- /_api/replication/logger-first-tick
- /_api/replication/server-id
- /_api/replication/server-id